### PR TITLE
import jest defaults from jest-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "babel-traverse": "^6.14.1",
     "babylon": "^6.14.1",
+    "jest-config": "^23.6.0",
     "jest-snapshot": "^23.6.0"
   },
   "typings": "index.d.ts"

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -11,6 +11,7 @@ import type {Options, SpawnOptions} from './types';
 
 import {ChildProcess} from 'child_process';
 import EventEmitter from 'events';
+import {defaults as jestConfigDefaults} from 'jest-config';
 import ProjectWorkspace from './project_workspace';
 import {createProcess} from './Process';
 
@@ -56,11 +57,9 @@ export default class Settings extends EventEmitter {
       shell: options && options.shell,
     };
 
-    // Defaults for a Jest project
-    this.settings = {
-      testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)+(spec|test).js?(x)'],
-      testRegex: ['(/__tests__/.*|\\.(test|spec))\\.jsx?$'],
-    };
+    const {testMatch, testRegex} = jestConfigDefaults;
+
+    this.settings = {testMatch, testRegex};
 
     this.configs = [this.settings];
     this._jsonPattern = new RegExp(/^[\s]*\{/gm);


### PR DESCRIPTION
I got a conflict when deleting this from Jest's source tree, so I think it makes sense to remove the hard-coding.

There are some comments at the top of the file about defaults, do you want more from it?