### PR TITLE
Replace `Settings` class by `getSettings` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ Bug-fixes within the same version aren't needed
 
 * upgrade to the latest jest version (24.7.x) - connectdotz
 
-* `Settings.settings` no longer contains the default configuration but starts with `undefined` - stephtr
+* Replace the `Settings` class with a `getSettings` function - stephtr
 
-  Before accessing this property, one has to run `Settings.getConfig`.
+  `getSettings` now simply returns a promise resolving to jest's config.
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Bug-fixes within the same version aren't needed
 
 * upgrade to the latest jest version (24.7.x) - connectdotz
 
-* Replace the `Settings` class with a `getSettings` function - stephtr
+* [breaking change] Replace the `Settings` class with a `getSettings` function - stephtr
 
   `getSettings` now simply returns a promise resolving to jest's config.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Bug-fixes within the same version aren't needed
 
 * upgrade to the latest jest version (24.7.x) - connectdotz
 
+* `Settings.settings` no longer contains the default configuration but starts with `undefined` - stephtr
+
+  Before accessing this property, one has to run `Settings.getConfig`.
+
 -->
 
 ### 25.0.0

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/flow'],
+  presets: [
+    [
+      '@babel/preset-env',
+      { useBuiltIns: 'usage' }
+    ],
+    '@babel/flow',
+  ],
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@
 
 import {EventEmitter} from 'events';
 import {ChildProcess} from 'child_process';
+import {Config as JestConfig} from '@jest/types';
 
 export interface SpawnOptions {
   shell?: boolean;
@@ -33,15 +34,9 @@ export class Runner extends EventEmitter {
   runJestWithUpdateForSnapshots(completion: () => void, args?: string[]): void;
 }
 
-
-export interface ProjectConfiguration {
-  testRegex: string | string[];
-  testMatch: string[];
-};
-
 export interface JestSettings {
   jestVersionMajor: number;
-  configs: ProjectConfiguration[];
+  configs: JestConfig.ProjectConfig[];
 };
 
 export function parseSettings(text: string, debug: boolean = false): JestSettings;

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,19 +33,18 @@ export class Runner extends EventEmitter {
   runJestWithUpdateForSnapshots(completion: () => void, args?: string[]): void;
 }
 
-export interface ConfigRepresentation {
-  testRegex: string | string[],
-  testMatch: string[],
+
+export interface ProjectConfiguration {
+  testRegex: string | string[];
+  testMatch: string[];
 };
 
-export class Settings extends EventEmitter {
-  constructor(workspace: ProjectWorkspace, options?: Options);
-  getConfigs(completed: Function): void;
-  getConfig(completed: Function, index?: number): void;
-  jestVersionMajor: number | null;
-  configs: ConfigRepresentation[];
-  settings?: ConfigRepresentation;
-}
+export interface JestSettings {
+  jestVersionMajor: number;
+  configs: ProjectConfiguration[];
+};
+
+export function parseSettings(text: string, debug: boolean = false): JestSettings;
 
 export class ProjectWorkspace {
   constructor(

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,14 +33,18 @@ export class Runner extends EventEmitter {
   runJestWithUpdateForSnapshots(completion: () => void, args?: string[]): void;
 }
 
+export interface ConfigRepresentation {
+  testRegex: string | string[],
+  testMatch: string[],
+};
+
 export class Settings extends EventEmitter {
   constructor(workspace: ProjectWorkspace, options?: Options);
-  getConfig(completed: Function): void;
+  getConfigs(completed: Function): void;
+  getConfig(completed: Function, index?: number): void;
   jestVersionMajor: number | null;
-  settings: {
-    testRegex: string,
-    testMatch: string[],
-  };
+  configs: ConfigRepresentation[];
+  settings?: ConfigRepresentation;
 }
 
 export class ProjectWorkspace {

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ export interface JestSettings {
   configs: JestConfig.ProjectConfig[];
 };
 
-export function parseSettings(text: string, debug: boolean = false): JestSettings;
+export function getSettings(workspace: ProjectWorkspace, options?: Options): Promise<JestSettings>;
 
 export class ProjectWorkspace {
   constructor(

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   "dependencies": {
     "@babel/traverse": "^7.1.2",
     "babylon": "^6.14.1",
-    "jest-config": "^24.7.0",
     "jest-snapshot": "^24.7.0",
     "typescript": "^3.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@babel/traverse": "^7.1.2",
+    "@jest/types": "^24.8.0",
     "babylon": "^6.14.1",
     "jest-snapshot": "^24.7.0",
     "typescript": "^3.4.3"

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -7,11 +7,11 @@
  * @flow
  */
 
-import {ChildProcess} from 'child_process';
+import { ChildProcess } from 'child_process';
 import EventEmitter from 'events';
-import type {Options, SpawnOptions} from './types';
+import type { Options, SpawnOptions } from './types';
 import ProjectWorkspace from './project_workspace';
-import {createProcess} from './Process';
+import { createProcess } from './Process';
 
 // This class represents the the configuration of Jest's process
 // the interface below can be used to show what we use, as currently the whole
@@ -21,89 +21,76 @@ import {createProcess} from './Process';
 
 type Glob = string;
 
-type ConfigRepresentation = {
+type ProjectConfiguration = {
   testRegex: string | Array<string>,
   testMatch: Array<Glob>,
 };
 
-type ConfigRepresentations = Array<ConfigRepresentation>;
+type JestSettings = {
+  jestVersionMajor: number,
+  configs: ProjectConfiguration[],
+};
 
-export default class Settings extends EventEmitter {
-  getConfigProcess: ChildProcess;
+function parseSettings(text: string, debug: Boolean = false): JestSettings {
+  _jsonPattern = new RegExp(/^[\s]*\{/gm);
+  let settings = null;
 
-  jestVersionMajor: number | null;
+  try {
+    settings = JSON.parse(text);
+  } catch (err) {
+    // skip the non-json content, if any
+    const idx = text.search(_jsonPattern);
+    if (idx > 0) {
+      if (debug) {
+        // eslint-disable-next-line no-console
+        console.log(`skip config output noise: ${text.substring(0, idx)}`);
+      }
+      return parseSettings(text.substring(idx));
+    }
+    // eslint-disable-next-line no-console
+    console.warn(`failed to parse config: \n${text}\nerror: ${err}`);
+    throw err;
+  }
 
-  _createProcess: (workspace: ProjectWorkspace, args: Array<string>, options: SpawnOptions) => ChildProcess;
+  const jestVersionMajor = parseInt(settings.version.split('.').shift(), 10);
+  if (debug) {
+    // eslint-disable-next-line no-console
+    console.log(`found config jestVersionMajor=${jestVersionMajor}`);
+  }
 
-  configs: ConfigRepresentations;
+  return {
+    jestVersionMajor,
+    configs: Array.isArray(settings.configs) ? settings.configs : [settings.config],
+  };
+}
 
-  settings: ?ConfigRepresentation;
-
-  workspace: ProjectWorkspace;
-
-  spawnOptions: SpawnOptions;
-
-  _jsonPattern: RegExp;
-
-  constructor(workspace: ProjectWorkspace, options?: Options) {
-    super();
-    this.workspace = workspace;
-    this._createProcess = (options && options.createProcess) || createProcess;
-    this.spawnOptions = {
+export function getSettings(workspace: ProjectWorkspace, options?: Options): Promise<JestSettings> {
+  return new Promise((resolve, reject) => {
+    const _createProcess = (options && options.createProcess) || createProcess;
+    const spawnOptions = {
       shell: options && options.shell,
     };
+    const getConfigProcess = _createProcess(workspace, ['--showConfig'], spawnOptions);
 
-    this.configs = [];
-    this._jsonPattern = new RegExp(/^[\s]*\{/gm);
-  }
+    const configString = '';
+    getConfigProcess.stdout.on('data', (data: Buffer) => {
+      configString += data.toString();
+    });
 
-  _parseConfig(text: string): void {
-    let settings = null;
+    const rejected = false;
+    getConfigProcess.stderr.on('data', (data: Buffer) => {
+      rejected = true;
+      reject(data.toString());
+    });
 
-    try {
-      settings = JSON.parse(text);
-    } catch (err) {
-      // skip the non-json content, if any
-      const idx = text.search(this._jsonPattern);
-      if (idx > 0) {
-        if (this.workspace.debug) {
-          // eslint-disable-next-line no-console
-          console.log(`skip config output noise: ${text.substring(0, idx)}`);
+    getConfigProcess.on('close', () => {
+      if (!rejected) {
+        try {
+          resolve(parseSettings(configString, workspace.debug));
+        } catch (err) {
+          reject(err);
         }
-        this._parseConfig(text.substring(idx));
-        return;
       }
-      // eslint-disable-next-line no-console
-      console.warn(`failed to parse config: \n${text}\nerror: ${err}`);
-      throw err;
-    }
-    this.jestVersionMajor = parseInt(settings.version.split('.').shift(), 10);
-    this.configs = this.jestVersionMajor >= 21 ? settings.configs : [settings.config];
-
-    if (this.workspace.debug) {
-      // eslint-disable-next-line no-console
-      console.log(`found config jestVersionMajor=${this.jestVersionMajor}`);
-    }
-  }
-
-  getConfigs(completed: any) {
-    this.getConfigProcess = this._createProcess(this.workspace, ['--showConfig'], this.spawnOptions);
-
-    this.getConfigProcess.stdout.on('data', (data: Buffer) => {
-      this._parseConfig(data.toString());
     });
-
-    // They could have an older build of Jest which
-    // would error with `--showConfig`
-    this.getConfigProcess.on('close', () => {
-      completed();
-    });
-  }
-
-  getConfig(completed: any, index: number = 0) {
-    this.getConfigs(() => {
-      this.settings = this.configs[index];
-      completed();
-    });
-  }
+  });
 }

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -7,9 +7,7 @@
  * @flow
  */
 
-import {ChildProcess} from 'child_process';
-import EventEmitter from 'events';
-import type {Options, SpawnOptions} from './types';
+import type {Options} from './types';
 import ProjectWorkspace from './project_workspace';
 import {createProcess} from './Process';
 
@@ -64,7 +62,7 @@ function parseSettings(text: string, debug: ?boolean = false): JestSettings {
   };
 }
 
-export function getSettings(workspace: ProjectWorkspace, options?: Options): Promise<JestSettings> {
+export default function getSettings(workspace: ProjectWorkspace, options?: Options): Promise<JestSettings> {
   return new Promise((resolve, reject) => {
     const _createProcess = (options && options.createProcess) || createProcess;
     const spawnOptions = {

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -10,15 +10,19 @@
 import {ChildProcess} from 'child_process';
 import EventEmitter from 'events';
 import type {Options, SpawnOptions} from './types';
-import type {Config as JestConfig} from '@jest/types';
 import ProjectWorkspace from './project_workspace';
 import {createProcess} from './Process';
 
 type Glob = string;
 
+type ProjectConfiguration = {
+  testRegex: string | Array<string>,
+  testMatch: Array<Glob>,
+};
+
 type JestSettings = {
   jestVersionMajor: number,
-  configs: JestConfig.ProjectConfig[],
+  configs: ProjectConfiguration[],
 };
 
 function parseSettings(text: string, debug: ?boolean = false): JestSettings {

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -13,13 +13,11 @@ import type { Options, SpawnOptions } from './types';
 import ProjectWorkspace from './project_workspace';
 import { createProcess } from './Process';
 
-// This class represents the the configuration of Jest's process
-// the interface below can be used to show what we use, as currently the whole
-// settings object will be in memory.
-
-// For now, this is all we care about inside the config
-
 type Glob = string;
+
+// The interface below can be used to show what we use, as currently the whole
+// settings object will be in memory.
+// For now, this is all we care about inside the config
 
 type ProjectConfiguration = {
   testRegex: string | Array<string>,

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -7,37 +7,29 @@
  * @flow
  */
 
-import { ChildProcess } from 'child_process';
+import {ChildProcess} from 'child_process';
 import EventEmitter from 'events';
-import type { Options, SpawnOptions } from './types';
+import type {Options, SpawnOptions} from './types';
+import type {Config as JestConfig} from '@jest/types';
 import ProjectWorkspace from './project_workspace';
-import { createProcess } from './Process';
+import {createProcess} from './Process';
 
 type Glob = string;
 
-// The interface below can be used to show what we use, as currently the whole
-// settings object will be in memory.
-// For now, this is all we care about inside the config
-
-type ProjectConfiguration = {
-  testRegex: string | Array<string>,
-  testMatch: Array<Glob>,
-};
-
 type JestSettings = {
   jestVersionMajor: number,
-  configs: ProjectConfiguration[],
+  configs: JestConfig.ProjectConfig[],
 };
 
-function parseSettings(text: string, debug: Boolean = false): JestSettings {
-  _jsonPattern = new RegExp(/^[\s]*\{/gm);
+function parseSettings(text: string, debug: ?boolean = false): JestSettings {
+  const jsonPattern = new RegExp(/^[\s]*\{/gm);
   let settings = null;
 
   try {
     settings = JSON.parse(text);
   } catch (err) {
     // skip the non-json content, if any
-    const idx = text.search(_jsonPattern);
+    const idx = text.search(jsonPattern);
     if (idx > 0) {
       if (debug) {
         // eslint-disable-next-line no-console
@@ -70,12 +62,12 @@ export function getSettings(workspace: ProjectWorkspace, options?: Options): Pro
     };
     const getConfigProcess = _createProcess(workspace, ['--showConfig'], spawnOptions);
 
-    const configString = '';
+    let configString = '';
     getConfigProcess.stdout.on('data', (data: Buffer) => {
       configString += data.toString();
     });
 
-    const rejected = false;
+    let rejected = false;
     getConfigProcess.stderr.on('data', (data: Buffer) => {
       rejected = true;
       reject(data.toString());

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -15,6 +15,12 @@ import {createProcess} from './Process';
 
 type Glob = string;
 
+// This class represents the configuration of Jest's process.
+// The interface below can be used to show what we use, as currently the whole
+// settings object will be in memory.
+// As soon as the code will be converted to TypeScript, this will be removed
+// in favor of `@jest/types`, which exports the full config interface.
+
 type ProjectConfiguration = {
   testRegex: string | Array<string>,
   testMatch: Array<Glob>,

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -9,19 +9,13 @@
 
 import {ChildProcess} from 'child_process';
 import EventEmitter from 'events';
-import {defaults as jestConfigDefaults} from 'jest-config';
 import type {Options, SpawnOptions} from './types';
 import ProjectWorkspace from './project_workspace';
 import {createProcess} from './Process';
 
 // This class represents the the configuration of Jest's process
-// we want to start with the defaults then override whatever they output
 // the interface below can be used to show what we use, as currently the whole
 // settings object will be in memory.
-
-// Ideally anything you care about adding should have a default in
-// the constructor see https://jestjs.io/docs/configuration.html
-// for full deets
 
 // For now, this is all we care about inside the config
 
@@ -43,7 +37,7 @@ export default class Settings extends EventEmitter {
 
   configs: ConfigRepresentations;
 
-  settings: ConfigRepresentation;
+  settings: ?ConfigRepresentation;
 
   workspace: ProjectWorkspace;
 
@@ -59,11 +53,7 @@ export default class Settings extends EventEmitter {
       shell: options && options.shell,
     };
 
-    const {testMatch, testRegex} = jestConfigDefaults;
-
-    this.settings = {testMatch, testRegex};
-
-    this.configs = [this.settings];
+    this.configs = [];
     this._jsonPattern = new RegExp(/^[\s]*\{/gm);
   }
 

--- a/src/__tests__/settings.test.js
+++ b/src/__tests__/settings.test.js
@@ -11,7 +11,7 @@
 
 import EventEmitter from 'events';
 import ProjectWorkspace from '../project_workspace';
-import {getSettings} from '../Settings';
+import getSettings from '../Settings';
 
 function prepareProcess() {
   const mockProcess: any = new EventEmitter();
@@ -104,7 +104,7 @@ describe('getSettings', () => {
     const workspace = new ProjectWorkspace(rootPath, pathToJest, pathToConfig, localJestMajorVersion);
 
     const {createProcess} = prepareProcess();
-    const settingsPromise = getSettings(workspace, {
+    getSettings(workspace, {
       createProcess,
       shell: true,
     });
@@ -125,7 +125,6 @@ describe('getSettings', () => {
 
   describe('parse config', () => {
     const workspace = new ProjectWorkspace('root_path', 'path_to_jest', 'test', 1000);
-    const createProcess = jest.fn();
 
     const json = `{ 
       "version": "23.2.0",

--- a/src/__tests__/settings.test.js
+++ b/src/__tests__/settings.test.js
@@ -14,7 +14,7 @@ import ProjectWorkspace from '../project_workspace';
 import { getSettings } from '../Settings';
 
 function prepareProcess() {
-  const mockProcess = new EventEmitter();
+  const mockProcess: any = new EventEmitter();
   mockProcess.stdout = new EventEmitter();
   mockProcess.stderr = new EventEmitter();
   return {
@@ -133,7 +133,7 @@ describe('getSettings', () => {
         "testRegex": "some-regex"
       }]
     }`;
-    const run_test = async (text: string, expected_version: number = 23, expected_regex: string = 'some-regex'): void => {
+    const run_test = async (text: string, expected_version: number = 23, expected_regex: string = 'some-regex'): Promise<void> => {
       expect.assertions(2);
       const { mockProcess, createProcess } = prepareProcess();
       const buffer = Buffer.from(text);

--- a/src/__tests__/settings.test.js
+++ b/src/__tests__/settings.test.js
@@ -11,7 +11,7 @@
 
 import EventEmitter from 'events';
 import ProjectWorkspace from '../project_workspace';
-import { getSettings } from '../Settings';
+import {getSettings} from '../Settings';
 
 function prepareProcess() {
   const mockProcess: any = new EventEmitter();
@@ -36,7 +36,7 @@ describe('getSettings', () => {
       version: '19.0.0',
     };
 
-    const { mockProcess, createProcess } = prepareProcess();
+    const {mockProcess, createProcess} = prepareProcess();
     const buffer = Buffer.from(JSON.stringify(json));
     const settingsPromise = getSettings(workspace, {
       createProcess,
@@ -64,7 +64,7 @@ describe('getSettings', () => {
       version: '21.0.0',
     };
 
-    const { mockProcess, createProcess } = prepareProcess();
+    const {mockProcess, createProcess} = prepareProcess();
     const buffer = Buffer.from(JSON.stringify(json));
     const settingsPromise = getSettings(workspace, {
       createProcess,
@@ -82,7 +82,7 @@ describe('getSettings', () => {
     expect.assertions(1);
     const workspace = new ProjectWorkspace('root_path', 'path_to_jest', 'test', 1000);
 
-    const { mockProcess, createProcess } = prepareProcess();
+    const {mockProcess, createProcess} = prepareProcess();
     const settingsPromise = getSettings(workspace, {
       createProcess,
     });
@@ -103,7 +103,7 @@ describe('getSettings', () => {
     const rootPath = 'root_path';
     const workspace = new ProjectWorkspace(rootPath, pathToJest, pathToConfig, localJestMajorVersion);
 
-    const { createProcess } = prepareProcess();
+    const {createProcess} = prepareProcess();
     const settingsPromise = getSettings(workspace, {
       createProcess,
       shell: true,
@@ -133,16 +133,20 @@ describe('getSettings', () => {
         "testRegex": "some-regex"
       }]
     }`;
-    const run_test = async (text: string, expected_version: number = 23, expected_regex: string = 'some-regex'): Promise<void> => {
+    const run_test = async (
+      text: string,
+      expected_version: number = 23,
+      expected_regex: string = 'some-regex'
+    ): Promise<void> => {
       expect.assertions(2);
-      const { mockProcess, createProcess } = prepareProcess();
+      const {mockProcess, createProcess} = prepareProcess();
       const buffer = Buffer.from(text);
       const settingsPromise = getSettings(workspace, {
         createProcess,
       });
       mockProcess.stdout.emit('data', buffer);
       mockProcess.emit('close');
-      
+
       const settings = await settingsPromise;
       expect(settings.jestVersionMajor).toBe(expected_version);
       expect(settings.configs[0].testRegex).toBe(expected_regex);

--- a/src/__tests__/settings.test.js
+++ b/src/__tests__/settings.test.js
@@ -21,7 +21,6 @@ describe('Settings', () => {
     };
     const settings = new Settings(workspace, options);
     expect(settings.workspace).toEqual(workspace);
-    expect(settings.settings).toEqual(expect.any(Object));
     expect(settings.spawnOptions).toEqual(options);
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import * as Process from './Process';
 
 import ProjectWorkspace from './project_workspace';
 import Runner from './Runner';
-import {getSettings} from './Settings';
+import getSettings from './Settings';
 import Snapshot from './Snapshot';
 import {
   Expect,

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import * as Process from './Process';
 
 import ProjectWorkspace from './project_workspace';
 import Runner from './Runner';
-import { getSettings } from './Settings';
+import {getSettings} from './Settings';
 import Snapshot from './Snapshot';
 import {
   Expect,

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import * as Process from './Process';
 
 import ProjectWorkspace from './project_workspace';
 import Runner from './Runner';
-import Settings from './Settings';
+import { getSettings } from './Settings';
 import Snapshot from './Snapshot';
 import {
   Expect,
@@ -39,7 +39,7 @@ module.exports = {
   Process,
   ProjectWorkspace,
   Runner,
-  Settings,
+  getSettings,
   Snapshot,
   TestReconciler,
   parse,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3264,7 +3264,7 @@ jest-cli@^24.7.1:
     realpath-native "^1.1.0"
     yargs "^12.0.2"
 
-jest-config@^24.7.0, jest-config@^24.7.1:
+jest-config@^24.7.1:
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-24.7.1.tgz#6c1dd4db82a89710a3cf66bdba97827c9a1cf052"
   integrity sha512-8FlJNLI+X+MU37j7j8RE4DnJkvAghXmBWdArVzypW6WxfGuxiL/CCkzBg0gHtXhD2rxla3IMOSUAHylSKYJ83g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,6 +875,15 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
+"@jest/types@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.8.0.tgz#f31e25948c58f0abd8c845ae26fcea1491dea7ad"
+  integrity sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^12.0.9"
+
 "@octokit/endpoint@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-4.0.0.tgz#97032a6690ef1cf9576ab1b1582c0ac837e3b5b6"
@@ -955,10 +964,30 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/istanbul-lib-coverage@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
+  integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
+
 "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz#1eb8c033e98cf4e1a4cedcaf8bcafe8cb7591e85"
   integrity sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==
+
+"@types/istanbul-lib-report@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#e5471e7fa33c61358dd38426189c037a58433b8c"
+  integrity sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz#7a8cbf6a406f36c8add871625b278eaf0b0d255a"
+  integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
Until now `Settings.settings` had been populated by the constructor using Jest's default values.
This however had a few disadvantages:

- In order to get the default values from Jest (one string and one string array), we had a dependency on `jest-config`, which by itself pulled in a large amount of further dependencies.
- In my opinion there are hardly any reasons why one would need Jest's default values. Usually one is interested in the precise settings being used in a specific workspace. Returning some generic default values only makes someone potentially forget about calling `getConfigs`.

As an alternative I propose to set `Settings.settings` to `undefined` instead (and `Settings.configs` to an empty array), until one of the getConfigs functions has been called. This will be a breaking change and if accepted, should probably wait until the next major version.