### PR TITLE
Add custom short message for @testing-library/react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Bug-fixes within the same version aren't needed
   projects that link with this package no longer need to add `jest-test-typescript-parser` package separately. The newly exposed `parse` function can select the proper parser based on file extension.
 
 * fix a few race condition errors in Runner (#9) - connectdotz
-  - concurrent Runner output to the same hard coded output file: added optional 'outputFileSuffix' parameter. 
+  - concurrent Runner output to the same hard coded output file: added optional 'outputFileSuffix' parameter.
   - jest process output parser sometimes failed to identify testResults message.
 
 * `TestReconciler` will now report test locations from jest '--testLocationInResults' output
@@ -26,6 +26,8 @@ Bug-fixes within the same version aren't needed
 
   `getSettings` now simply returns a promise resolving to jest's config.
 
+* custom short message for @testing-library/react - jmarceli
+
 -->
 
 ### 25.0.0
@@ -37,8 +39,7 @@ in your head, consider this a 1.0 kinda thing.
 
   This is because the codebase was migrated with Jest, and now uses functions
   from the master builds that don't seem to be available on the latest production
-  versions of jest-snapshot/. If someone wants to backport this to the prod builds 
+  versions of jest-snapshot/. If someone wants to backport this to the prod builds
   look at the usage of the `buildSnapshotResolver`
 
 - Adds the ability to parse describe blocks - https://github.com/facebook/jest/pull/7215
-

--- a/babel.config.js
+++ b/babel.config.js
@@ -6,4 +6,5 @@ module.exports = {
     ],
     '@babel/flow',
   ],
+  plugins: ['@babel/plugin-transform-dotall-regex']
 };

--- a/fixtures/failing-jsons/failing_testing-library-react.json
+++ b/fixtures/failing-jsons/failing_testing-library-react.json
@@ -1,0 +1,54 @@
+{
+  "numFailedTestSuites": 1,
+  "numFailedTests": 1,
+  "numPassedTestSuites": 0,
+  "numPassedTests": 0,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 0,
+  "numTodoTests": 0,
+  "numTotalTestSuites": 1,
+  "numTotalTests": 1,
+  "openHandles": [],
+  "snapshot": {
+    "added": 0,
+    "didUpdate": false,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesRemovedList": [],
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "uncheckedKeysByFile": [],
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1569272945008,
+  "success": false,
+  "testResults": [
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [],
+          "failureMessages": [
+            "Error: Unable to find an element with the text: Learn React123. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.\n\n\u001b[36m<body>\u001b[39m\n  \u001b[36m<div>\u001b[39m\n    \u001b[36m<div\u001b[39m\n      \u001b[33mclass\u001b[39m=\u001b[32m\"root\"\u001b[39m\n    \u001b[36m>\u001b[39m\n      \u001b[0mLearn React\u001b[0m\n    \u001b[36m</div>\u001b[39m\n  \u001b[36m</div>\u001b[39m\n\u001b[36m</body>\u001b[39m\n    at getElementError (/Users/jmarceli/work/rnd/cra-base-2019-09-21/node_modules/@testing-library/dom/dist/query-helpers.js:22:10)\n    at args (/Users/jmarceli/work/rnd/cra-base-2019-09-21/node_modules/@testing-library/dom/dist/query-helpers.js:76:13)\n    at args (/Users/jmarceli/work/rnd/cra-base-2019-09-21/node_modules/@testing-library/dom/dist/query-helpers.js:59:17)\n    at Object.getByText (/Users/jmarceli/work/rnd/cra-base-2019-09-21/src/pages/Home.test.tsx:8:10)\n    at Object.asyncJestTest (/Users/jmarceli/work/rnd/cra-base-2019-09-21/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:102:37)\n    at resolve (/Users/jmarceli/work/rnd/cra-base-2019-09-21/node_modules/jest-jasmine2/build/queueRunner.js:43:12)\n    at new Promise (<anonymous>)\n    at mapper (/Users/jmarceli/work/rnd/cra-base-2019-09-21/node_modules/jest-jasmine2/build/queueRunner.js:26:19)\n    at promise.then (/Users/jmarceli/work/rnd/cra-base-2019-09-21/node_modules/jest-jasmine2/build/queueRunner.js:73:41)\n    at process._tickCallback (internal/process/next_tick.js:68:7)"
+          ],
+          "fullName": "renders without crashing",
+          "location": {"column": 1, "line": 5},
+          "status": "failed",
+          "title": "renders without crashing"
+        }
+      ],
+      "endTime": 1569272947046,
+      "message": "  ● renders without crashing\n\n    Unable to find an element with the text: Learn React123. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.\n\n    \u001b[36m<body>\u001b[39m\n      \u001b[36m<div>\u001b[39m\n        \u001b[36m<div\u001b[39m\n          \u001b[33mclass\u001b[39m=\u001b[32m\"root\"\u001b[39m\n        \u001b[36m>\u001b[39m\n          \u001b[0mLearn React\u001b[0m\n        \u001b[36m</div>\u001b[39m\n      \u001b[36m</div>\u001b[39m\n    \u001b[36m</body>\u001b[39m\n\n       6 |   const { getByText } = render(<Home />);\n       7 | \n    >  8 |   expect(getByText('Learn React123')).toBeInTheDocument();\n         |          ^\n       9 | });\n      10 | \n\n      at getElementError (node_modules/@testing-library/dom/dist/query-helpers.js:22:10)\n      at args (node_modules/@testing-library/dom/dist/query-helpers.js:76:13)\n      at args (node_modules/@testing-library/dom/dist/query-helpers.js:59:17)\n      at Object.getByText (src/pages/Home.test.tsx:8:10)\n",
+      "name": "/Users/jmarceli/work/rnd/cra-base-2019-09-21/src/pages/Home.test.tsx",
+      "startTime": 1569272946033,
+      "status": "failed",
+      "summary": ""
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@babel/cli": "^7.1.2",
     "@babel/core": "^7.1.2",
+    "@babel/plugin-transform-dotall-regex": "^7.6.2",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-flow": "^7.0.0",
     "babel-core": "7.0.0-bridge.0",

--- a/src/__tests__/test_reconciler.test.js
+++ b/src/__tests__/test_reconciler.test.js
@@ -203,7 +203,8 @@ describe('Terse Messages', () => {
 
     const terseForTest = name => parser.stateForTestAssertion(file, name);
 
-    const message = `Error: Unable to find an element with the text: Learn React123. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.\n\n\u001b[36m<body>\u001b[39m\n  \u001b[36m<div>\u001b[39m\n    \u001b[36m<div\u001b[39m\n      \u001b[33mclass\u001b[39m=\u001b[32m\"root\"\u001b[39m\n    \u001b[36m>\u001b[39m\n      \u001b[0mLearn React\u001b[0m\n    \u001b[36m</div>\u001b[39m\n  \u001b[36m</div>\u001b[39m\n\u001b[36m</body>\u001b[39m`;
+    const message =
+      'Error: Unable to find an element with the text: Learn React123. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.\n\n\u001b[36m<body>\u001b[39m\n  \u001b[36m<div>\u001b[39m\n    \u001b[36m<div\u001b[39m\n      \u001b[33mclass\u001b[39m=\u001b[32m"root"\u001b[39m\n    \u001b[36m>\u001b[39m\n      \u001b[0mLearn React\u001b[0m\n    \u001b[36m</div>\u001b[39m\n  \u001b[36m</div>\u001b[39m\n\u001b[36m</body>\u001b[39m';
     const testName = 'renders without crashing';
     expect(terseForTest(testName)).toHaveProperty('terseMessage', message);
   });

--- a/src/__tests__/test_reconciler.test.js
+++ b/src/__tests__/test_reconciler.test.js
@@ -158,12 +158,10 @@ Expected value to be falsy, instead received
 describe('Terse Messages', () => {
   let parser: TestReconciler;
 
-  beforeEach(() => {
+  it('handles shrinking a snapshot message', () => {
     parser = new TestReconciler();
     reconcilerWithFile(parser, 'failing_expects.json');
-  });
 
-  it('handles shrinking a snapshot message', () => {
     const file = '/Users/orta/dev/projects/artsy/js/libs/jest-snapshots-svg/src/_tests/example.test.ts';
 
     const terseForTest = name => parser.stateForTestAssertion(file, name);
@@ -194,6 +192,19 @@ describe('Terse Messages', () => {
 
     message = 'Expected value to be truthy, instead received null';
     testName = 'truthy';
+    expect(terseForTest(testName)).toHaveProperty('terseMessage', message);
+  });
+
+  it('handles shrinking a @testing-library/react message', () => {
+    parser = new TestReconciler();
+    reconcilerWithFile(parser, 'failing_testing-library-react.json');
+
+    const file = '/Users/jmarceli/work/rnd/cra-base-2019-09-21/src/pages/Home.test.tsx';
+
+    const terseForTest = name => parser.stateForTestAssertion(file, name);
+
+    const message = `Error: Unable to find an element with the text: Learn React123. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.\n\n\u001b[36m<body>\u001b[39m\n  \u001b[36m<div>\u001b[39m\n    \u001b[36m<div\u001b[39m\n      \u001b[33mclass\u001b[39m=\u001b[32m\"root\"\u001b[39m\n    \u001b[36m>\u001b[39m\n      \u001b[0mLearn React\u001b[0m\n    \u001b[36m</div>\u001b[39m\n  \u001b[36m</div>\u001b[39m\n\u001b[36m</body>\u001b[39m`;
+    const testName = 'renders without crashing';
     expect(terseForTest(testName)).toHaveProperty('terseMessage', message);
   });
 });

--- a/src/test_reconciler.js
+++ b/src/test_reconciler.js
@@ -105,6 +105,11 @@ export default class TestReconciler {
       return 'New snapshot is ready to write';
     }
 
+    // Improve @testing-library/react error messages handling
+    if (string.startsWith('Error: Unable to find an element with the text')) {
+      return string;
+    }
+
     return string
       .split('\n')
       .splice(2)

--- a/src/test_reconciler.js
+++ b/src/test_reconciler.js
@@ -13,6 +13,10 @@ import type {TestFileAssertionStatus, TestAssertionStatus, TestReconciliationSta
 
 import type {FormattedAssertionResult, FormattedTestResults} from '../types/TestResult';
 
+// Regex which defines which short messages are considered to be valid
+// \s\S - stands for any character including new line https://stackoverflow.com/questions/1068280/javascript-regex-multiline-flag-doesnt-work
+const validShortMessage = /expected[\s\S]*received/i;
+
 /**
  *  You have a Jest test runner watching for changes, and you have
  *  an extension that wants to know where to show errors after file parsing.
@@ -105,8 +109,7 @@ export default class TestReconciler {
       return 'New snapshot is ready to write';
     }
 
-    // Standard Jest error message
-    if (string.startsWith('Error: expect')) {
+    if (validShortMessage.test(string)) {
       return string
         .split('\n')
         .splice(2)

--- a/src/test_reconciler.js
+++ b/src/test_reconciler.js
@@ -14,8 +14,7 @@ import type {TestFileAssertionStatus, TestAssertionStatus, TestReconciliationSta
 import type {FormattedAssertionResult, FormattedTestResults} from '../types/TestResult';
 
 // Regex which defines which short messages are considered to be valid
-// \s\S - stands for any character including new line https://stackoverflow.com/questions/1068280/javascript-regex-multiline-flag-doesnt-work
-const validShortMessage = /expected[\s\S]*received/i;
+const validShortMessage = /Expected.*[R|r]eceived/s;
 
 /**
  *  You have a Jest test runner watching for changes, and you have

--- a/src/test_reconciler.js
+++ b/src/test_reconciler.js
@@ -105,18 +105,19 @@ export default class TestReconciler {
       return 'New snapshot is ready to write';
     }
 
-    // Improve @testing-library/react error messages handling
-    if (string.startsWith('Error: Unable to find an element with the text')) {
-      return string;
+    // Standard Jest error message
+    if (string.startsWith('Error: expect')) {
+      return string
+        .split('\n')
+        .splice(2)
+        .join('')
+        .replace(/\s\s+/g, ' ')
+        .replace('Received:', ', Received:')
+        .split('Difference:')[0];
     }
 
-    return string
-      .split('\n')
-      .splice(2)
-      .join('')
-      .replace(/\s\s+/g, ' ')
-      .replace('Received:', ', Received:')
-      .split('Difference:')[0];
+    // Non standard message
+    return string;
   }
 
   // Pull the line out from the stack trace

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,13 @@
   dependencies:
     lodash "^4.17.10"
 
+"@babel/helper-regex@^7.4.4":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.5.5.tgz#0aa6824f7100a2e0e89c1527c23936c152cab351"
+  integrity sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==
+  dependencies:
+    lodash "^4.17.13"
+
 "@babel/helper-remap-async-to-generator@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz#361d80821b6f38da75bd3f0785ece20a88c5fe7f"
@@ -431,6 +438,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
+
+"@babel/plugin-transform-dotall-regex@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz#44abb948b88f0199a627024e1508acaf8dc9b2f9"
+  integrity sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.6.0"
 
 "@babel/plugin-transform-duplicate-keys@^7.0.0":
   version "7.0.0"
@@ -4050,6 +4066,11 @@ lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
+lodash@^4.17.13:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log-driver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
@@ -5052,6 +5073,13 @@ regenerate-unicode-properties@^7.0.0:
   dependencies:
     regenerate "^1.4.0"
 
+regenerate-unicode-properties@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"
+  integrity sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==
+  dependencies:
+    regenerate "^1.4.0"
+
 regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
@@ -5099,15 +5127,39 @@ regexpu-core@^4.1.3, regexpu-core@^4.2.0:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.0.2"
 
+regexpu-core@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.6.0.tgz#2037c18b327cfce8a6fea2a4ec441f2432afb8b6"
+  integrity sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
+  dependencies:
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^8.1.0"
+    regjsgen "^0.5.0"
+    regjsparser "^0.6.0"
+    unicode-match-property-ecmascript "^1.0.4"
+    unicode-match-property-value-ecmascript "^1.1.0"
+
 regjsgen@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.4.0.tgz#c1eb4c89a209263f8717c782591523913ede2561"
   integrity sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==
 
+regjsgen@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.0.tgz#a7634dc08f89209c2049adda3525711fb97265dd"
+  integrity sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==
+
 regjsparser@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.3.0.tgz#3c326da7fcfd69fa0d332575a41c8c0cdf588c96"
   integrity sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==
+  dependencies:
+    jsesc "~0.5.0"
+
+regjsparser@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.0.tgz#f1e6ae8b7da2bae96c99399b868cd6c933a2ba9c"
+  integrity sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==
   dependencies:
     jsesc "~0.5.0"
 
@@ -5847,6 +5899,11 @@ unicode-match-property-value-ecmascript@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz#9f1dc76926d6ccf452310564fd834ace059663d4"
   integrity sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==
+
+unicode-match-property-value-ecmascript@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz#5b4b426e08d13a80365e0d657ac7a6c1ec46a277"
+  integrity sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==
 
 unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
I think that short messages for @testing-library/react should have more content than the others. 

The current implementation looks as follows:

<img width="699" alt="no-testing-library-support" src="https://user-images.githubusercontent.com/4281333/65464101-6174a200-de59-11e9-96e1-713374112ab6.png">

While after this MR it will look like that:

<img width="700" alt="testing-library-support" src="https://user-images.githubusercontent.com/4281333/65464122-6c2f3700-de59-11e9-833e-a9582b21e8fb.png">

Together with https://github.com/jest-community/vscode-jest/pull/501 it should provide a complete solution for https://github.com/jest-community/vscode-jest/issues/493

Please let me know how do you feel about this change.