### PR TITLE
prepare for release 27.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+-->
 
+### 27.0.0
+* [breaking change] Replace the `Settings` class with a `getSettings` function - stephtr
+
+  `getSettings` now simply returns a promise resolving to jest's config.
+
+* Improved handling of quoted commands, arguments and escaped spaces - omjadas
+
+### 26.0.0
 * incorporate `jest-test-typescript-parser` into this package since it has been deprecated from the original `jest` reposition (#9) - connectdotz
 
   projects that link with this package no longer need to add `jest-test-typescript-parser` package separately. The newly exposed `parse` function can select the proper parser based on file extension.
@@ -21,14 +30,6 @@ Bug-fixes within the same version aren't needed
   Turning on the verbose will output caught exception for debugging purpose.
 
 * upgrade to the latest jest version (24.7.x) - connectdotz
-
-* [breaking change] Replace the `Settings` class with a `getSettings` function - stephtr
-
-  `getSettings` now simply returns a promise resolving to jest's config.
-
-* Improved handling of quoted commands, arguments and escaped spaces - omjadas
-
--->
 
 ### 25.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-editor-support",
-  "version": "26.0.0-beta",
+  "version": "27.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/jest-community/jest-editor-support"


### PR DESCRIPTION
this package has been on 26.0.0-beta for a while, probably should have cut a formal release sooner... With the external API change, I think it's time to cut a new major release - 27.0.0.  



