### PR TITLE
Add --bail and --runInBand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
+* Add `--runInBand` and `--bail` options support - [@jmarceli](https://github.com/jmarceli)
 
 -->
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,8 @@ export interface Options {
   testNamePattern?: string;
   testFileNamePattern?: string;
   reporters?: string[];
+  runInBand?: boolean;
+  bail?: boolean;
 }
 
 export class Runner extends EventEmitter {

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -83,6 +83,12 @@ export default class Runner extends EventEmitter {
         args.push('--reporters', reporter);
       });
     }
+    if (this.options.runInBand === true) {
+      args.push('--runInBand');
+    }
+    if (this.options.bail === true) {
+      args.push('--bail');
+    }
 
     this.debugprocess = this._createProcess(this.workspace, args);
     this.debugprocess.stdout.on('data', (data: Buffer) => {

--- a/src/__tests__/runner.test.js
+++ b/src/__tests__/runner.test.js
@@ -288,6 +288,32 @@ describe('Runner', () => {
       const lastIndex = args.lastIndexOf('--reporters');
       expect(args[lastIndex + 1]).toBe(expected[1]);
     });
+
+    it('calls createProcess with --runInBand arg when provided', () => {
+      const expected = '--runInBand';
+
+      const workspace: any = {};
+      const options = {runInBand: true};
+      const sut = new Runner(workspace, options);
+      sut.start(false);
+
+      const args = (createProcess: any).mock.calls[0][1];
+      const index = args.indexOf(expected);
+      expect(index).not.toBe(-1);
+    });
+
+    it('calls createProcess with --bail arg when provided', () => {
+      const expected = '--bail';
+
+      const workspace: any = {};
+      const options = {bail: true};
+      const sut = new Runner(workspace, options);
+      sut.start(false);
+
+      const args = (createProcess: any).mock.calls[0][1];
+      const index = args.indexOf(expected);
+      expect(index).not.toBe(-1);
+    });
   });
 
   describe('closeProcess', () => {

--- a/src/types.js
+++ b/src/types.js
@@ -21,6 +21,8 @@ export type Options = {
   testNamePattern?: string,
   testFileNamePattern?: string,
   reporters?: string[],
+  runInBand?: boolean,
+  bail?: boolean,
 };
 
 /**


### PR DESCRIPTION
Using `--bail` and `--runInBand` may sometimes improve DX and possibly mitigate performance issues. It might be the first approach to address issues like https://github.com/jest-community/vscode-jest/issues/455