### PR TITLE
prepare for release 27.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 build/
 coverage/
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ babel.config.js
 prettier.config.js
 dangerfile.js
 yarn.lock
+*.tgz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-editor-support",
-  "version": "27.1.0",
+  "version": "27.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/jest-community/jest-editor-support"


### PR DESCRIPTION
accidentally packed the "jest-editor-support-27.1.0.tgz" in the npm package. This is to remove that and update the ignorefiles to make sure it will not happen again.