### PR TITLE
address orphan process issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "typescript.validate.enable": true,
   "javascript.validate.enable": false,
-  "eslint.autoFixOnSave": true
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* Address orphan process issue - @connectdotz
+  
 -->
 
 ### 27.1.0

--- a/src/Process.js
+++ b/src/Process.js
@@ -35,6 +35,10 @@ export const createProcess = (workspace: ProjectWorkspace, args: Array<string>):
     cwd: workspace.rootPath,
     env,
     shell: true,
+    // run in detached mode so the process will be the group leader and any subsequent process spawned
+    // within can be later killed as a group to prevent orphan processes.
+    // see https://nodejs.org/api/child_process.html#child_process_options_detached
+    detached: true,
   };
 
   if (workspace.debug) {

--- a/src/Process.js
+++ b/src/Process.js
@@ -35,10 +35,10 @@ export const createProcess = (workspace: ProjectWorkspace, args: Array<string>):
     cwd: workspace.rootPath,
     env,
     shell: true,
-    // run in detached mode so the process will be the group leader and any subsequent process spawned
+    // for non-windows: run in detached mode so the process will be the group leader and any subsequent process spawned
     // within can be later killed as a group to prevent orphan processes.
     // see https://nodejs.org/api/child_process.html#child_process_options_detached
-    detached: true,
+    detached: process.platform !== 'win32',
   };
 
   if (workspace.debug) {

--- a/src/__tests__/process.test.js
+++ b/src/__tests__/process.test.js
@@ -82,7 +82,7 @@ describe('createProcess', () => {
     expect(spawn.mock.calls[0][2].cwd).toBe(workspace.rootPath);
   });
 
-  it('should set the "shell" and "detached" property', () => {
+  it('should set the "shell" property', () => {
     const expected = true;
     const workspace: any = {pathToJest: ''};
     const args = [];
@@ -90,5 +90,23 @@ describe('createProcess', () => {
 
     expect(spawn.mock.calls[0][2].shell).toBe(expected);
     expect(spawn.mock.calls[0][2].detached).toBe(expected);
+  });
+  it('should set "detached" to true for non-windows system', () => {
+    const workspace: any = {pathToJest: ''};
+    const args = [];
+
+    const savedProcess = process;
+    const processMock = {...process};
+    global.process = processMock;
+
+    processMock.platform = 'darwin';
+    createProcess(workspace, args);
+    expect(spawn.mock.calls[0][2].detached).toBe(true);
+
+    processMock.platform = 'win32';
+    createProcess(workspace, args);
+    expect(spawn.mock.calls[1][2].detached).toBe(false);
+
+    global.process = savedProcess;
   });
 });

--- a/src/__tests__/process.test.js
+++ b/src/__tests__/process.test.js
@@ -89,7 +89,6 @@ describe('createProcess', () => {
     createProcess(workspace, args);
 
     expect(spawn.mock.calls[0][2].shell).toBe(expected);
-    expect(spawn.mock.calls[0][2].detached).toBe(expected);
   });
   it('should set "detached" to true for non-windows system', () => {
     const workspace: any = {pathToJest: ''};

--- a/src/__tests__/process.test.js
+++ b/src/__tests__/process.test.js
@@ -82,12 +82,13 @@ describe('createProcess', () => {
     expect(spawn.mock.calls[0][2].cwd).toBe(workspace.rootPath);
   });
 
-  it('should set the "shell" property', () => {
+  it('should set the "shell" and "detached" property', () => {
     const expected = true;
     const workspace: any = {pathToJest: ''};
     const args = [];
     createProcess(workspace, args);
 
     expect(spawn.mock.calls[0][2].shell).toBe(expected);
+    expect(spawn.mock.calls[0][2].detached).toBe(expected);
   });
 });

--- a/src/__tests__/runner.test.js
+++ b/src/__tests__/runner.test.js
@@ -44,6 +44,17 @@ const _path = jest.requireActual('path');
 const fixtures = _path.resolve(__dirname, '../../fixtures');
 
 describe('Runner', () => {
+  const processKill = jest.fn();
+  let originalProcessKill;
+
+  beforeAll(() => {
+    originalProcessKill = process.kill;
+    (process: any).kill = processKill;
+  });
+
+  afterAll(() => {
+    (process: any).kill = originalProcessKill;
+  });
   describe('constructor', () => {
     it('does not set watchMode', () => {
       const workspace: any = {};
@@ -323,15 +334,16 @@ describe('Runner', () => {
       expect(spawn).toBeCalledWith('taskkill', ['/pid', '123', '/T', '/F']);
     });
 
-    it('calls kill() to close the process on POSIX', () => {
+    it('calls process.kill() with processGroup id to close the process on POSIX', () => {
       const workspace: any = {};
       const sut = new Runner(workspace);
       process.platform = 'posix';
       const kill = jest.fn();
-      sut.debugprocess = ({kill}: any);
+      sut.debugprocess = ({kill, pid: 123}: any);
       sut.closeProcess();
 
-      expect(kill).toBeCalledWith();
+      expect(kill).not.toBeCalled();
+      expect(processKill).toBeCalledWith(-123);
     });
 
     it('clears the debugprocess property', () => {
@@ -343,216 +355,216 @@ describe('Runner', () => {
       expect(sut.debugprocess).not.toBeDefined();
     });
   });
-});
 
-describe('events', () => {
-  let runner: Runner;
-  let fakeProcess: ChildProcess;
+  describe('events', () => {
+    let runner: Runner;
+    let fakeProcess: ChildProcess;
 
-  beforeEach(() => {
-    jest.resetAllMocks();
+    beforeEach(() => {
+      jest.resetAllMocks();
 
-    fakeProcess = (new EventEmitter(): any);
-    fakeProcess.stdout = new EventEmitter();
-    fakeProcess.stderr = new EventEmitter();
-    fakeProcess.kill = () => {};
+      fakeProcess = (new EventEmitter(): any);
+      fakeProcess.stdout = new EventEmitter();
+      fakeProcess.stderr = new EventEmitter();
+      fakeProcess.kill = () => {};
 
-    (createProcess: any).mockImplementation(() => fakeProcess);
+      (createProcess: any).mockImplementation(() => fakeProcess);
 
-    const workspace = new ProjectWorkspace('.', 'node_modules/.bin/jest', 'test', 18);
-    runner = new Runner(workspace);
+      const workspace = new ProjectWorkspace('.', 'node_modules/.bin/jest', 'test', 18);
+      runner = new Runner(workspace);
 
-    // Sets it up and registers for notifications
-    runner.start();
-  });
+      // Sets it up and registers for notifications
+      runner.start();
+    });
 
-  it('expects JSON from both stdout and stderr, then it passes the JSON', () => {
-    const data = jest.fn();
-    runner.on('executableJSON', data);
+    it('expects JSON from both stdout and stderr, then it passes the JSON', () => {
+      const data = jest.fn();
+      runner.on('executableJSON', data);
 
-    runner.outputPath = `${fixtures}/failing-jsons/failing_jest_json.json`;
-
-    const doTest = (out: stream$Readable) => {
-      data.mockClear();
-
-      // Emitting data through stdout should trigger sending JSON
-      out.emit('data', 'Test results written to file');
-      expect(data).toBeCalled();
-
-      // And lets check what we emit
-      const dataAtPath = readFileSync(runner.outputPath);
-      const storedJSON = JSON.parse(dataAtPath.toString());
-      expect(data.mock.calls[0][0]).toEqual(storedJSON);
-    };
-
-    doTest(fakeProcess.stdout);
-    doTest(fakeProcess.stderr);
-  });
-
-  it('emits errors when process errors', () => {
-    const error = jest.fn();
-    runner.on('terminalError', error);
-    fakeProcess.emit('error', {});
-    expect(error).toBeCalled();
-  });
-
-  it('emits debuggerProcessExit when process exits', () => {
-    const close = jest.fn();
-    runner.on('debuggerProcessExit', close);
-    fakeProcess.emit('exit');
-    expect(close).toBeCalled();
-  });
-
-  it('should start jest process after killing the old process', () => {
-    runner.closeProcess();
-    runner.start();
-
-    expect(createProcess).toHaveBeenCalledTimes(2);
-  });
-
-  describe('stdout.on("data")', () => {
-    it('should emit an "executableJSON" event with the "noTestsFound" meta data property set', () => {
-      const listener = jest.fn();
-      runner.on('executableJSON', listener);
       runner.outputPath = `${fixtures}/failing-jsons/failing_jest_json.json`;
-      (runner: any).doResultsFollowNoTestsFoundMessage = jest.fn().mockReturnValueOnce(true);
-      fakeProcess.stdout.emit('data', 'Test results written to file');
 
-      expect(listener.mock.calls[0].length).toBe(2);
-      expect(listener.mock.calls[0][1]).toEqual({noTestsFound: true});
+      const doTest = (out: stream$Readable) => {
+        data.mockClear();
+
+        // Emitting data through stdout should trigger sending JSON
+        out.emit('data', 'Test results written to file');
+        expect(data).toBeCalled();
+
+        // And lets check what we emit
+        const dataAtPath = readFileSync(runner.outputPath);
+        const storedJSON = JSON.parse(dataAtPath.toString());
+        expect(data.mock.calls[0][0]).toEqual(storedJSON);
+      };
+
+      doTest(fakeProcess.stdout);
+      doTest(fakeProcess.stderr);
     });
 
-    it('should clear the message type history', () => {
-      runner.outputPath = `${fixtures}/failing-jsons/failing_jest_json.json`;
-      runner.prevMessageTypes.push(messageTypes.noTests);
-      fakeProcess.stdout.emit('data', 'Test results written to file');
-
-      expect(runner.prevMessageTypes.length).toBe(0);
-    });
-  });
-
-  describe('stderr.on("data")', () => {
-    it('should identify the message type', () => {
-      (runner: any).findMessageType = jest.fn();
-      const expected = {};
-      fakeProcess.stderr.emit('data', expected);
-
-      expect(runner.findMessageType).toBeCalledWith(expected);
+    it('emits errors when process errors', () => {
+      const error = jest.fn();
+      runner.on('terminalError', error);
+      fakeProcess.emit('error', {});
+      expect(error).toBeCalled();
     });
 
-    it('should add the type to the message type history when known', () => {
-      (runner: any).findMessageType = jest.fn().mockReturnValueOnce(messageTypes.noTests);
-      fakeProcess.stderr.emit('data', Buffer.from(''));
-
-      expect(runner.prevMessageTypes).toEqual([messageTypes.noTests]);
+    it('emits debuggerProcessExit when process exits', () => {
+      const close = jest.fn();
+      runner.on('debuggerProcessExit', close);
+      fakeProcess.emit('exit');
+      expect(close).toBeCalled();
     });
 
-    it('should clear the message type history when the type is unknown', () => {
-      (runner: any).findMessageType = jest.fn().mockReturnValueOnce(messageTypes.unknown);
-      fakeProcess.stderr.emit('data', Buffer.from(''));
+    it('should start jest process after killing the old process', () => {
+      runner.closeProcess();
+      runner.start();
 
-      expect(runner.prevMessageTypes).toEqual([]);
+      expect(createProcess).toHaveBeenCalledTimes(2);
     });
 
-    it('should emit an "executableStdErr" event with the type', () => {
-      const listener = jest.fn();
-      const data = Buffer.from('');
-      const type = {};
-      const meta = {type};
-      (runner: any).findMessageType = jest.fn().mockReturnValueOnce(type);
+    describe('stdout.on("data")', () => {
+      it('should emit an "executableJSON" event with the "noTestsFound" meta data property set', () => {
+        const listener = jest.fn();
+        runner.on('executableJSON', listener);
+        runner.outputPath = `${fixtures}/failing-jsons/failing_jest_json.json`;
+        (runner: any).doResultsFollowNoTestsFoundMessage = jest.fn().mockReturnValueOnce(true);
+        fakeProcess.stdout.emit('data', 'Test results written to file');
 
-      runner.on('executableStdErr', listener);
-      fakeProcess.stderr.emit('data', data, meta);
+        expect(listener.mock.calls[0].length).toBe(2);
+        expect(listener.mock.calls[0][1]).toEqual({noTestsFound: true});
+      });
 
-      expect(listener).toBeCalledWith(data, meta);
+      it('should clear the message type history', () => {
+        runner.outputPath = `${fixtures}/failing-jsons/failing_jest_json.json`;
+        runner.prevMessageTypes.push(messageTypes.noTests);
+        fakeProcess.stdout.emit('data', 'Test results written to file');
+
+        expect(runner.prevMessageTypes.length).toBe(0);
+      });
     });
 
-    it('should track when "No tests found related to files changed since the last commit" is received', () => {
-      const data = Buffer.from(
-        'No tests found related to files changed since last commit.\n' +
-          'Press `a` to run all tests, or run Jest with `--watchAll`.'
-      );
-      fakeProcess.stderr.emit('data', data);
+    describe('stderr.on("data")', () => {
+      it('should identify the message type', () => {
+        (runner: any).findMessageType = jest.fn();
+        const expected = {};
+        fakeProcess.stderr.emit('data', expected);
 
-      expect(runner.prevMessageTypes).toEqual([messageTypes.noTests]);
+        expect(runner.findMessageType).toBeCalledWith(expected);
+      });
+
+      it('should add the type to the message type history when known', () => {
+        (runner: any).findMessageType = jest.fn().mockReturnValueOnce(messageTypes.noTests);
+        fakeProcess.stderr.emit('data', Buffer.from(''));
+
+        expect(runner.prevMessageTypes).toEqual([messageTypes.noTests]);
+      });
+
+      it('should clear the message type history when the type is unknown', () => {
+        (runner: any).findMessageType = jest.fn().mockReturnValueOnce(messageTypes.unknown);
+        fakeProcess.stderr.emit('data', Buffer.from(''));
+
+        expect(runner.prevMessageTypes).toEqual([]);
+      });
+
+      it('should emit an "executableStdErr" event with the type', () => {
+        const listener = jest.fn();
+        const data = Buffer.from('');
+        const type = {};
+        const meta = {type};
+        (runner: any).findMessageType = jest.fn().mockReturnValueOnce(type);
+
+        runner.on('executableStdErr', listener);
+        fakeProcess.stderr.emit('data', data, meta);
+
+        expect(listener).toBeCalledWith(data, meta);
+      });
+
+      it('should track when "No tests found related to files changed since the last commit" is received', () => {
+        const data = Buffer.from(
+          'No tests found related to files changed since last commit.\n' +
+            'Press `a` to run all tests, or run Jest with `--watchAll`.'
+        );
+        fakeProcess.stderr.emit('data', data);
+
+        expect(runner.prevMessageTypes).toEqual([messageTypes.noTests]);
+      });
+
+      it('should track when "No tests found related to files changed since master" is received', () => {
+        const data = Buffer.from(
+          'No tests found related to files changed since "master".\n' +
+            'Press `a` to run all tests, or run Jest with `--watchAll`.'
+        );
+        fakeProcess.stderr.emit('data', data);
+
+        expect(runner.prevMessageTypes).toEqual([messageTypes.noTests]);
+      });
+
+      it('should clear the message type history when any other other data is received', () => {
+        const data = Buffer.from('');
+        fakeProcess.stderr.emit('data', data);
+
+        expect(runner.prevMessageTypes).toEqual([]);
+      });
     });
 
-    it('should track when "No tests found related to files changed since master" is received', () => {
-      const data = Buffer.from(
-        'No tests found related to files changed since "master".\n' +
-          'Press `a` to run all tests, or run Jest with `--watchAll`.'
-      );
-      fakeProcess.stderr.emit('data', data);
+    describe('findMessageType()', () => {
+      it('should return "unknown" when the message is not matched', () => {
+        const buf = Buffer.from('');
+        expect(runner.findMessageType(buf)).toBe(messageTypes.unknown);
+      });
 
-      expect(runner.prevMessageTypes).toEqual([messageTypes.noTests]);
+      it('should identify "No tests found related to files changed since last commit."', () => {
+        const buf = Buffer.from(
+          'No tests found related to files changed since last commit.\n' +
+            'Press `a` to run all tests, or run Jest with `--watchAll`.'
+        );
+        expect(runner.findMessageType(buf)).toBe(messageTypes.noTests);
+      });
+
+      it('should identify "No tests found related to files changed since git ref."', () => {
+        const buf = Buffer.from(
+          'No tests found related to files changed since "master".\n' +
+            'Press `a` to run all tests, or run Jest with `--watchAll`.'
+        );
+        expect(runner.findMessageType(buf)).toBe(messageTypes.noTests);
+      });
+
+      it('should identify the "Watch Usage" prompt', () => {
+        const buf = Buffer.from('\n\nWatch Usage\n...');
+        expect(runner.findMessageType(buf)).toBe(messageTypes.watchUsage);
+      });
+      it('should prioritize message types accordingly.', () => {
+        // testResults > noTests > watchUsage > unknown
+
+        const testResults = 'Test results written to file\n';
+        const noTests = 'No tests found related to files changed since "master".\n';
+        const watchUsage = 'Press `a` to run all tests, or run Jest with `--watchAll`\n';
+        const unknownMsg = 'whatever...\n';
+
+        expect(runner.findMessageType(Buffer.from(noTests + testResults))).toBe(messageTypes.testResults);
+
+        expect(runner.findMessageType(Buffer.from(noTests + watchUsage))).toBe(messageTypes.noTests);
+
+        expect(runner.findMessageType(Buffer.from(noTests + watchUsage + testResults))).toBe(messageTypes.testResults);
+
+        expect(runner.findMessageType(Buffer.from(unknownMsg + testResults))).toBe(messageTypes.testResults);
+      });
     });
 
-    it('should clear the message type history when any other other data is received', () => {
-      const data = Buffer.from('');
-      fakeProcess.stderr.emit('data', data);
+    describe('doResultsFollowNoTestsFoundMessage()', () => {
+      it('should return true when the last message on stderr was "No tests found..."', () => {
+        runner.prevMessageTypes.push(messageTypes.noTests);
+        expect(runner.doResultsFollowNoTestsFoundMessage()).toBe(true);
+      });
 
-      expect(runner.prevMessageTypes).toEqual([]);
-    });
-  });
+      it('should return true when the last two messages on stderr were "No tests found..." and "Watch Usage"', () => {
+        runner.prevMessageTypes.push(messageTypes.noTests, messageTypes.watchUsage);
+        expect(runner.doResultsFollowNoTestsFoundMessage()).toBe(true);
+      });
 
-  describe('findMessageType()', () => {
-    it('should return "unknown" when the message is not matched', () => {
-      const buf = Buffer.from('');
-      expect(runner.findMessageType(buf)).toBe(messageTypes.unknown);
-    });
-
-    it('should identify "No tests found related to files changed since last commit."', () => {
-      const buf = Buffer.from(
-        'No tests found related to files changed since last commit.\n' +
-          'Press `a` to run all tests, or run Jest with `--watchAll`.'
-      );
-      expect(runner.findMessageType(buf)).toBe(messageTypes.noTests);
-    });
-
-    it('should identify "No tests found related to files changed since git ref."', () => {
-      const buf = Buffer.from(
-        'No tests found related to files changed since "master".\n' +
-          'Press `a` to run all tests, or run Jest with `--watchAll`.'
-      );
-      expect(runner.findMessageType(buf)).toBe(messageTypes.noTests);
-    });
-
-    it('should identify the "Watch Usage" prompt', () => {
-      const buf = Buffer.from('\n\nWatch Usage\n...');
-      expect(runner.findMessageType(buf)).toBe(messageTypes.watchUsage);
-    });
-    it('should prioritize message types accordingly.', () => {
-      // testResults > noTests > watchUsage > unknown
-
-      const testResults = 'Test results written to file\n';
-      const noTests = 'No tests found related to files changed since "master".\n';
-      const watchUsage = 'Press `a` to run all tests, or run Jest with `--watchAll`\n';
-      const unknownMsg = 'whatever...\n';
-
-      expect(runner.findMessageType(Buffer.from(noTests + testResults))).toBe(messageTypes.testResults);
-
-      expect(runner.findMessageType(Buffer.from(noTests + watchUsage))).toBe(messageTypes.noTests);
-
-      expect(runner.findMessageType(Buffer.from(noTests + watchUsage + testResults))).toBe(messageTypes.testResults);
-
-      expect(runner.findMessageType(Buffer.from(unknownMsg + testResults))).toBe(messageTypes.testResults);
-    });
-  });
-
-  describe('doResultsFollowNoTestsFoundMessage()', () => {
-    it('should return true when the last message on stderr was "No tests found..."', () => {
-      runner.prevMessageTypes.push(messageTypes.noTests);
-      expect(runner.doResultsFollowNoTestsFoundMessage()).toBe(true);
-    });
-
-    it('should return true when the last two messages on stderr were "No tests found..." and "Watch Usage"', () => {
-      runner.prevMessageTypes.push(messageTypes.noTests, messageTypes.watchUsage);
-      expect(runner.doResultsFollowNoTestsFoundMessage()).toBe(true);
-    });
-
-    it('should return false otherwise', () => {
-      runner.prevMessageTypes.length = 0;
-      expect(runner.doResultsFollowNoTestsFoundMessage()).toBe(false);
+      it('should return false otherwise', () => {
+        runner.prevMessageTypes.length = 0;
+        expect(runner.doResultsFollowNoTestsFoundMessage()).toBe(false);
+      });
     });
   });
 });

--- a/src/__tests__/runner.test.js
+++ b/src/__tests__/runner.test.js
@@ -345,6 +345,21 @@ describe('Runner', () => {
       expect(kill).not.toBeCalled();
       expect(processKill).toBeCalledWith(-123);
     });
+    it('if process.kill() failed, it will fallback to subprocess.kill', () => {
+      const workspace: any = {};
+      const sut = new Runner(workspace);
+      process.platform = 'posix';
+      const kill = jest.fn();
+      sut.debugprocess = ({kill, pid: 123}: any);
+
+      processKill.mockImplementation(() => {
+        throw new Error('for testing');
+      });
+
+      sut.closeProcess();
+
+      expect(kill).toBeCalled();
+    });
 
     it('clears the debugprocess property', () => {
       const workspace: any = {};


### PR DESCRIPTION
see jest-community/vscode-jest#550, specifically the 2nd scenario mentioned [here](https://github.com/jest-community/vscode-jest/issues/550#issuecomment-615930298)

> when the spawned process spawns another child process in the background, such as in react-scripts use case, even when we close the jest process, the react-script spawned process will not be terminated. 

It is clearly mentioned in nodejs [child_process kill](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal), I think we just missed it when switching to the `shell` option 😱 ...

> On Linux, child processes of child processes will not be terminated when attempting to kill their parent. This is likely to happen when running a new process in a shell or with the use of the shell option of ChildProcess

anyway, there are a few possible ways to fix this issue, looks like on windows, which we have been using shell option way back, it spawned an external `taskkill` to kill all child processes. At least on Unix like systems, it seems we could utilize the system's "process group" mechanism to create and terminate the child processes without spawning another external command nor introducing a 3rd party library... 

The "process group" mechanism in nodejs means to spawn a process with the "detached" option, which created a new process group that we can use later to kill every process within by `process.kill()` with the negative PID (served as PGID)

I tested this on mac and it seems to work as expected. I am a bit concern if this will work for all systems, so still keep the current behavior as the fallback. 

Also not sure if the `detached` flag has any unexpected effect on windows and if we should only turn this on for non-windows?

@stephtr or anyone has a windows system, would appreciate some quick test to verify all is well there. 