### PR TITLE
expose fullName and ancestorTitles for assertions and address parser parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Bug-fixes within the same version aren't needed
 ## Master
 * Replace babylon and typescript parsers with @babel/parser 7.x - @firsttris 
 * expose fullName and ancestorTitles to assertions - @connectdotz
+* fix regression: test.each is being ignored by parser - @connectdotz
 -->
 
 ### 27.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Bug-fixes within the same version aren't needed
 ## Master
 * Replace babylon and typescript parsers with @babel/parser 7.x - @firsttris 
 * expose fullName and ancestorTitles to assertions - @connectdotz
-* fix regression: test.each is being ignored by parser - @connectdotz
+* fix parser regression: test.each is being ignored by parser - @connectdotz
+* fix typescript parsing error - @connectdotz
 -->
 
 ### 27.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 * Replace babylon and typescript parsers with @babel/parser 7.x - @firsttris 
+* expose fullName and ancestorTitles to assertions - @connectdotz
 -->
 
 ### 27.2.0

--- a/fixtures/failing-jsons/with-ancestors-and-each.json
+++ b/fixtures/failing-jsons/with-ancestors-and-each.json
@@ -1,0 +1,117 @@
+{
+  "numFailedTestSuites": 1,
+  "numFailedTests": 2,
+  "numPassedTestSuites": 0,
+  "numPassedTests": 5,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 0,
+  "numTodoTests": 0,
+  "numTotalTestSuites": 1,
+  "numTotalTests": 7,
+  "openHandles": [],
+  "snapshot": {
+    "added": 0,
+    "didUpdate": false,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesRemovedList": [],
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "uncheckedKeysByFile": [],
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1590606132766,
+  "success": false,
+  "testResults": [
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "block-1",
+            "block-1-1"
+          ],
+          "failureMessages": [],
+          "fullName": "block-1 block-1-1 testing",
+          "location": null,
+          "status": "passed",
+          "title": "testing"
+        },
+        {
+          "ancestorTitles": [
+            "block-1"
+          ],
+          "failureMessages": [
+            "Error: whatever"
+          ],
+          "fullName": "block-1 test should fail",
+          "location": null,
+          "status": "failed",
+          "title": "test should fail"
+        },
+        {
+          "ancestorTitles": [],
+          "failureMessages": [],
+          "fullName": "test without describe",
+          "location": null,
+          "status": "passed",
+          "title": "test without describe"
+        },
+        {
+          "ancestorTitles": [
+            "block-2"
+          ],
+          "failureMessages": [
+            "Error: whatever"
+          ],
+          "fullName": "block-2 testing",
+          "location": null,
+          "status": "failed",
+          "title": "testing"
+        },
+        {
+          "ancestorTitles": [
+            "block-2"
+          ],
+          "failureMessages": [],
+          "fullName": "block-2 each test \"a\"",
+          "location": null,
+          "status": "passed",
+          "title": "each test \"a\""
+        },
+        {
+          "ancestorTitles": [
+            "block-2"
+          ],
+          "failureMessages": [],
+          "fullName": "block-2 each test \"b\"",
+          "location": null,
+          "status": "passed",
+          "title": "each test \"b\""
+        },
+        {
+          "ancestorTitles": [
+            "block-2"
+          ],
+          "failureMessages": [],
+          "fullName": "block-2 each test \"c\"",
+          "location": null,
+          "status": "passed",
+          "title": "each test \"c\""
+        }
+      ],
+      "endTime": 1590606133773,
+      "message": "whatever",
+      "name": "/test/tricky-test.ts",
+      "startTime": 1590606133162,
+      "status": "failed",
+      "summary": ""
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -8,7 +8,7 @@
 
 const fixtures = __dirname;
 
-function parserTests(parse: (file: string) => ParseResult) {
+function parserTests(parse: (file: string) => ParseResult, isTypescript = false) {
   const assertBlock = (block, start, end, name: ?string = null) => {
     expect(block.start).toEqual(start);
     expect(block.end).toEqual(end);
@@ -400,6 +400,17 @@ function parserTests(parse: (file: string) => ParseResult) {
       const itBlock = parseResult.itBlocks[0];
       assertBlock2(itBlock, 2, 7, 6, 9, 'each test %p');
       assertNameInfo(itBlock, 'each test %p', 3, 10, 3, 21);
+    });
+  });
+  describe('typescript specific', () => {
+    it('parser should not crash on ArrowFunctionExpression', () => {
+      if (!isTypescript) {
+        return;
+      }
+      const parseResult = parse(`${fixtures}/typescript/parse-error.example`);
+      expect(parseResult.describeBlocks.length).toEqual(0);
+      expect(parseResult.itBlocks.length).toEqual(0);
+      expect(parseResult.expects.length).toEqual(0);
     });
   });
 }

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -370,6 +370,38 @@ function parserTests(parse: (file: string) => ParseResult) {
       expect(block.children).toBeFalsy();
     });
   });
+  describe('jest.each', () => {
+    it('should be able to detect it.each', () => {
+      const data = `
+      it.each(['a', 'b', 'c'])('each test %p', (v) => {
+        expect(v).not.toBeUndefined();
+      });
+        `;
+      const parseResult = parse('whatever', data);
+      expect(parseResult.itBlocks.length).toEqual(1);
+      expect(parseResult.expects.length).toEqual(1);
+
+      const itBlock = parseResult.itBlocks[0];
+      assertBlock2(itBlock, 2, 7, 4, 9, 'each test %p');
+      assertNameInfo(itBlock, 'each test %p', 2, 33, 2, 44);
+    });
+    it('should be able to detect test.each with a bit different layout', () => {
+      const data = `
+      test.each(['a','b', 'c'])(
+        'each test %p', 
+        (v) => {
+        expect(v).not.toBeUndefined();
+      });
+          `;
+      const parseResult = parse('whatever', data);
+      expect(parseResult.itBlocks.length).toEqual(1);
+      expect(parseResult.expects.length).toEqual(1);
+
+      const itBlock = parseResult.itBlocks[0];
+      assertBlock2(itBlock, 2, 7, 6, 9, 'each test %p');
+      assertNameInfo(itBlock, 'each test %p', 3, 10, 3, 21);
+    });
+  });
 }
 
 module.exports = {

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -413,6 +413,27 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       expect(parseResult.expects.length).toEqual(0);
     });
   });
+  describe('parse error use case', () => {
+    it('https://github.com/jest-community/vscode-jest/issues/405', () => {
+      const data = `
+      describe('test', () => {
+        const a = [true, true, false];
+        a.forEach((item) => {
+          test(String(item), () => {
+            expect(item).toBe(false);
+          });
+        });
+      });
+      `;
+      const parseResult = parse('whatever', data);
+      expect(parseResult.itBlocks.length).toEqual(1);
+      expect(parseResult.expects.length).toEqual(1);
+
+      const itBlock = parseResult.itBlocks[0];
+      assertBlock2(itBlock, 5, 11, 7, 13, '__function__');
+      assertNameInfo(itBlock, '__function__', 5, 17, 5, 26);
+    });
+  });
 }
 
 module.exports = {

--- a/fixtures/typescript/parse-error.example
+++ b/fixtures/typescript/parse-error.example
@@ -1,0 +1,29 @@
+const makeWarning = (fileName: string) => (
+  messageType: MessageType,
+  contextType: ContextType,
+  source: ContainerNode<ItBlock> | DataNode<ItBlock>,
+  assertion?: ContainerNode<TestAssertionStatus> | DataNodeType<TestAssertionStatus>,
+  extraReason?: string
+): void => {
+  const output = (message: string): void =>
+    console.warn(`[${fileName}] ${message} \n source=`, source, `\n assertion=`, assertion);
+
+  const blockType = contextType === 'container' ? 'describe' : 'test';
+  switch (messageType) {
+    case 'context-mismatch':
+      output(
+        `!! context mismatched !! ${contextType} nodes are different under "${source.name}": `
+      );
+      break;
+    case 'match-failed': {
+      output(`!! match failed !! ${blockType}: "${source.name}": ${extraReason} `);
+      break;
+    }
+    case 'unusual-match': {
+      output(`unusual match: ${extraReason} : ${blockType} ${source.name}: `);
+      break;
+    }
+  }
+};
+
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -157,6 +157,8 @@ export interface TestFileAssertionStatus {
  */
 export interface TestAssertionStatus {
   title: string;
+  fullName: string;
+  ancestorTitles: string[];
   status: TestReconcilationState;
   message: string;
   shortMessage?: string;

--- a/src/__tests__/parsers/babel_typescript_parser.test.js
+++ b/src/__tests__/parsers/babel_typescript_parser.test.js
@@ -8,4 +8,4 @@
 import {parseTs} from '../../parsers/babel_parser';
 import {parserTests} from '../../../fixtures/parser_tests';
 
-parserTests(parseTs);
+parserTests(parseTs, true);

--- a/src/__tests__/test_reconciler.test.js
+++ b/src/__tests__/test_reconciler.test.js
@@ -83,6 +83,33 @@ Expected value to be falsy, instead received
       }
     });
   });
+  describe('with fullName and ancestorTitles', () => {
+    beforeEach(() => {
+      parser = new TestReconciler();
+      results = reconcilerWithFile(parser, 'with-ancestors-and-each.json');
+    });
+    it('can parse and preserve nested describe context', () => {
+      expect(results.length).toEqual(1);
+      const {assertions} = results[0];
+      if (assertions) {
+        expect(assertions.length).toEqual(7);
+        expect(assertions[0].fullName).toEqual('block-1 block-1-1 testing');
+        expect(assertions[0].ancestorTitles).toEqual(['block-1', 'block-1-1']);
+        expect(assertions[0].title).toEqual('testing');
+      } else {
+        expect(assertions).not.toBeNull();
+      }
+    });
+    it('test without describe, fullName is title and ancestorTitles is []', () => {
+      const {assertions} = results[0];
+      if (assertions) {
+        expect(assertions[2].ancestorTitles).toEqual([]);
+        expect(assertions[2].fullName).toEqual(assertions[2].title);
+      } else {
+        expect(assertions).not.toBeNull();
+      }
+    });
+  });
   describe('in a monorepo project', () => {
     beforeEach(() => {
       parser = new TestReconciler();

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -34,13 +34,20 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
     const arg = bNode.expression.arguments[0];
     let name = arg.value;
 
-    if (!name && arg.type === 'TemplateLiteral') {
-      name = _data.substring(arg.start + 1, arg.end - 1);
+    if (!name) {
+      switch (arg.type) {
+        case 'TemplateLiteral':
+          name = _data.substring(arg.start + 1, arg.end - 1);
+          break;
+        case 'CallExpression':
+          // a dynamic function: use a placeholder
+          name = '__function__';
+          break;
+        default:
+          throw new TypeError(`failed to update namedBlock from: ${JSON.stringify(bNode)}`);
+      }
     }
 
-    if (name == null) {
-      throw new TypeError(`failed to update namedBlock from: ${JSON.stringify(bNode)}`);
-    }
     nBlock.name = name;
     nBlock.nameRange = new ParsedRange(
       arg.loc.start.line,

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -70,9 +70,12 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
   // handle cases where it's a member expression (.only)
   const getNameForNode = node => {
     if (isFunctionCall(node) && node && node.expression && node.expression.callee) {
-      return (
-        node.expression.callee.name || (node.expression.callee.object ? node.expression.callee.object.name : undefined)
-      );
+      const name =
+        node.expression.callee.name ||
+        node.expression.callee.object?.name ||
+        node.expression.callee.callee?.object?.name;
+
+      return name;
     }
     return undefined;
   };

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -126,7 +126,7 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
     // Look through the node's children
     let child: ?ParsedNode;
 
-    if (!babylonParent.body) {
+    if (!babylonParent.body || !Array.isArray(babylonParent.body)) {
       return;
     }
 
@@ -198,6 +198,8 @@ export const plugins = [
   'partialApplication',
   'throwExpressions',
   'topLevelAwait',
+  ['decorators', {decoratorsBeforeExport: true}],
+  ['pipelineOperator', {proposal: 'smart'}],
 ];
 
 // Its not possible to use the parser with flow and typescript active at the same time

--- a/src/test_reconciler.js
+++ b/src/test_reconciler.js
@@ -91,6 +91,8 @@ export default class TestReconciler {
         terseMessage: terse,
         title: assertion.title,
         location,
+        fullName: assertion.fullName,
+        ancestorTitles: assertion.ancestorTitles,
       };
     });
   }

--- a/src/types.js
+++ b/src/types.js
@@ -39,6 +39,8 @@ export type TestReconciliationState =
  */
 export type TestAssertionStatus = {
   title: string,
+  fullName: string,
+  ancestorTitles: string[],
   status: TestReconciliationState,
   message: string,
   shortMessage: ?string,

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -107,6 +107,7 @@ export type AssertionResult = {|
 export type FormattedAssertionResult = {
   failureMessages: Array<string> | null,
   fullName: string,
+  ancestorTitles: Array<string>,
   location: ?Callsite,
   status: Status,
   title: string,
@@ -204,10 +205,7 @@ export type FormattedTestResults = {
 
 export type CodeCoverageReporter = any;
 
-export type CodeCoverageFormatter = (
-  coverage: ?RawCoverage,
-  reporter?: CodeCoverageReporter,
-) => ?Object;
+export type CodeCoverageFormatter = (coverage: ?RawCoverage, reporter?: CodeCoverageReporter) => ?Object;
 
 export type UncheckedSnapshot = {|
   filePath: string,


### PR DESCRIPTION
- expose `fullName` and `ancestorTitles` properties from jest assertions. This allows clients to build "context", describe/test hierarchy, for the tests.
- fix a few parser related issues