### PR TITLE
fix return statement without argument crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
-
+* fix parser crash for return statement without argument. - @connectdotz
 -->
 
 ### 28.0.0-beta.0

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -433,7 +433,7 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       assertBlock2(itBlock, 5, 11, 7, 13, '__function__');
       assertNameInfo(itBlock, '__function__', 5, 17, 5, 26);
     });
-    it.only('return statement without arguments should not crash', () => {
+    it('return statement without arguments should not crash', () => {
       const data = `
       it('test', () => {
         expect(true).toBe(true);

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -433,6 +433,17 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       assertBlock2(itBlock, 5, 11, 7, 13, '__function__');
       assertNameInfo(itBlock, '__function__', 5, 17, 5, 26);
     });
+    it.only('return statement without arguments should not crash', () => {
+      const data = `
+      it('test', () => {
+        expect(true).toBe(true);
+        return;
+      });
+      `;
+      const parseResult = parse('whatever', data);
+      expect(parseResult.itBlocks.length).toEqual(1);
+      expect(parseResult.expects.length).toEqual(1);
+    });
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
       "<rootDir>/build/",
       "<rootDir>/fixtures/"
     ],
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/fixtures/"
+    ],
     "transform": {
       "^.+\\.[t|j]sx?$": "babel-jest"
     }

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -161,7 +161,7 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
         isFunctionDeclaration(element.expression.right.type)
       ) {
         searchNodes(element.expression.right.body, parent);
-      } else if (element.type === 'ReturnStatement' && element.argument && element.argument.arguments) {
+      } else if (element.type === 'ReturnStatement' && element.argument?.arguments) {
         element.argument.arguments
           .filter(argument => isFunctionDeclaration(argument.type))
           .forEach(argument => searchNodes(argument.body, parent));

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -161,7 +161,7 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
         isFunctionDeclaration(element.expression.right.type)
       ) {
         searchNodes(element.expression.right.body, parent);
-      } else if (element.type === 'ReturnStatement' && element.argument.arguments) {
+      } else if (element.type === 'ReturnStatement' && element.argument && element.argument.arguments) {
         element.argument.arguments
           .filter(argument => isFunctionDeclaration(argument.type))
           .forEach(argument => searchNodes(argument.body, parent));


### PR DESCRIPTION
fix parsing error for  no argument return statement: `return;`