### PR TITLE
Bugfix: Recognize `it.only.each` and other chains off of it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
-* Detect Tagged Template Literal version of describe.each and it.each
-* Detect it when used with deep chain of modifiers ( e.g. `test.concurrent.only.each(table)(name, fn)`)
+* Detect Tagged Template Literal version of describe.each and it.each - @TheSench
+* Detect it when used with deep chain of modifiers (e.g. `test.concurrent.only.each(table)(name, fn)`) - @TheSench
 -->
 
 ### 28.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
+* Detect Tagged Template Literal version of describe.each and it.each
+* Detect it when used with deep chain of modifiers ( e.g. `test.concurrent.only.each(table)(name, fn)`)
 -->
 
 ### 28.0.0

--- a/fixtures/describe_eaches.example
+++ b/fixtures/describe_eaches.example
@@ -1,0 +1,36 @@
+// @flow
+describe.each(['a', 'b', 'c'])('works with old functions', function() {
+
+});
+
+describe.each(['a', 'b', 'c'])('works with new functions', () => {
+
+});
+
+describe.each(['a', 'b', 'c'])('works with flow functions', () => {
+  function foo(x: string): string { return x; }
+});
+
+describe.each(['a', 'b', 'c'])('works with JSX', () => {
+  const foo = () => <div></div>;
+});
+
+describe.only.each(['a', 'b', 'c'])('works with describe.only', () => {
+
+});
+
+describe.concurrent.each(['a', 'b', 'c'])('works with describe.concurrent', () => {
+
+});
+
+describe.concurrent.only.each(['a', 'b', 'c'])('works with describe.concurrent.only', () => {
+
+});
+
+describe.concurrent.skip.each(['a', 'b', 'c'])('works with describe.concurrent.skip', () => {
+
+});
+
+fdescribe.each(['a', 'b', 'c'])('works with fdescribe', () => {
+
+});

--- a/fixtures/each_tagged_templates.example
+++ b/fixtures/each_tagged_templates.example
@@ -1,0 +1,74 @@
+it.each`
+  a    | b    | expected
+  ${1} | ${1} | ${2}
+  ${1} | ${2} | ${3}
+  ${2} | ${1} | ${3}
+`('works with global tagged-template it.each', () => {
+  
+});
+
+test.each`
+  a    | b    | expected
+  ${1} | ${1} | ${2}
+  ${1} | ${2} | ${3}
+  ${2} | ${1} | ${3}
+`('works with global tagged-template test.each', () => {
+  
+});
+
+describe.each`
+  a    | b    | expected
+  ${1} | ${1} | ${2}
+  ${1} | ${2} | ${3}
+  ${2} | ${1} | ${3}
+`('tagged describe.each', () => {
+  it(`works with it inside tagged-template describe.each`, () => {
+
+  });
+
+  test(`works with test inside tagged-template describe.each`, () => {
+    
+  });
+});
+
+describe('normal describe', () => {
+  it.each`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+  `('works with tagged-template it.each inside normal describe', () => {
+    
+  });
+
+  test.each`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+  `('works with tagged-template test.each inside normal describe', () => {
+    
+  });
+});
+
+describe.each`
+  a    | b
+  ${1} | ${1}
+  ${1} | ${2}
+`('tagged describe.each 2', () => {
+  it.each`
+    c    | d
+    ${2} | ${2}
+    ${2} | ${3}
+  `('works with tagged-template it.each inside tagged-template describe.each', () => {
+    
+  });
+
+  test.each`
+    c    | d
+    ${2} | ${2}
+    ${2} | ${3}
+  `('works with tagged-template test.each inside tagged-template describe.each', () => {
+    
+  });
+});

--- a/fixtures/global_it_eaches.example
+++ b/fixtures/global_it_eaches.example
@@ -11,11 +11,23 @@ it.each(['a', 'b', 'c'])('works with flow functions', () => {
   function foo(x: string): string { return x; }
 });
 
-it.each(['a', 'b', 'c'])('works with JSX', ()=> {
+it.each(['a', 'b', 'c'])('works with JSX', () => {
   const foo = () => <div></div>;
-})
+});
 
 it.only.each(['a', 'b', 'c'])('works with it.only', () => {
+
+});
+
+it.concurrent.each(['a', 'b', 'c'])('works with it.concurrent', () => {
+
+});
+
+it.concurrent.only.each(['a', 'b', 'c'])('works with it.concurrent.only', () => {
+
+});
+
+it.concurrent.skip.each(['a', 'b', 'c'])('works with it.concurrent.skip', () => {
 
 });
 
@@ -28,5 +40,17 @@ test.each(['a', 'b', 'c'])('works with test', () => {
 });
 
 test.only.each(['a', 'b', 'c'])('works with test.only', () => {
+
+});
+
+test.concurrent.each(['a', 'b', 'c'])('works with test.concurrent', () => {
+
+});
+
+test.concurrent.only.each(['a', 'b', 'c'])('works with test.concurrent.only', () => {
+
+});
+
+test.concurrent.skip.each(['a', 'b', 'c'])('works with test.concurrent.skip', () => {
 
 });

--- a/fixtures/global_it_eaches.example
+++ b/fixtures/global_it_eaches.example
@@ -1,0 +1,32 @@
+// @flow
+it.each(['a', 'b', 'c'])('works with old functions', function() {
+
+});
+
+it.each(['a', 'b', 'c'])('works with new functions', () => {
+
+});
+
+it.each(['a', 'b', 'c'])('works with flow functions', () => {
+  function foo(x: string): string { return x; }
+});
+
+it.each(['a', 'b', 'c'])('works with JSX', ()=> {
+  const foo = () => <div></div>;
+})
+
+it.only.each(['a', 'b', 'c'])('works with it.only', () => {
+
+});
+
+fit.each(['a', 'b', 'c'])('works with fit', () => {
+
+});
+
+test.each(['a', 'b', 'c'])('works with test', () => {
+
+});
+
+test.only.each(['a', 'b', 'c'])('works with test.only', () => {
+
+});

--- a/fixtures/nested_eaches.example
+++ b/fixtures/nested_eaches.example
@@ -1,0 +1,59 @@
+describe('some context', () => {
+  it.each([1, 2])('it.each 1', () => {
+  });
+  it.each([1, 2])('it.each 2', () => {
+  });
+});
+
+describe('some other context', () => {
+  it.each([1, 2])('it.each 3', () => {
+  });
+});
+
+describe('with old functions', function() {
+  it.each([1, 2])('works with old functions', () => {
+  });
+});
+
+fdescribe('with fdescribe', () => {
+  it.each([1, 2])('works with fdescribe', () => {
+  });
+});
+
+describe.only('with describe.only', () => {
+  it.each([1, 2])('works with describe.only', () => {
+  });
+});
+
+describe.each([1, 2])('with describe.each', () => {
+  it.each([1, 2])('works with describe.each', () => {
+  });
+});
+
+describe('outer', () => {
+  describe('inner', () => {
+    it.each([1, 2])('works with inner describe', () => {
+    });
+  });
+  describe.each([1, 2])('inner', () => {
+    it.each([1, 2])('works with inner describe.each', () => {
+    });
+    it('normal it with inner describe.each', () => {
+    });
+  });
+});
+
+describe.each([1, 2])('outer describe.each', () => {
+  describe('inner', () => {
+    it.each([1, 2])('works with outer describe.each', () => {
+    });
+    it('normal it with outer describe.each', () => {
+    });
+  });
+  describe.each([1, 2])('inner', () => {
+    it.each([1, 2])('works with inner and outer describe.each', () => {
+    });
+    it('normal it with inner and outer describe.each', () => {
+    });
+  });
+});

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -25,9 +25,10 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       }).not.toThrow();
     });
   });
-  /**
-   * Simplify parseResult to make diffing easier during failed tests
-   */
+  const parseResultNames = (parseResult: ParseResult) => ({
+    itBlocks: parseResult.itBlocks.map(it => it.name),
+    describeBlocks: parseResult.describeBlocks.map(describe => describe.name)
+  });
   const simplifiedParseResult = (parseResult: ParseResult) => ({
     itBlocks: parseResult.itBlocks.map(it => ({
       name: it.name,
@@ -39,7 +40,18 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       start: describe.start,
       end: describe.end
     }))
-  })
+  });
+  /**
+   * Compare names, start, and end of each it/describe in parse result
+   */
+  const assertParseResultSimple = (parseResult: ParseResult, expectedSimplifiedParseResult) => {
+    // Check just names first
+    const names = parseResultNames(parseResult);
+    const expectedNames = parseResultNames(expectedSimplifiedParseResult);
+    expect(names).toMatchObject(expectedNames);
+    // Then check names, start, and end
+    expect(simplifiedParseResult(parseResult)).toMatchObject(expectedSimplifiedParseResult);
+  };
 
   describe('File Parsing for it blocks', () => {
     it('For the simplest it cases', () => {
@@ -404,8 +416,7 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
     it('For the simplest it.each cases', () => {
       const parseResult = parse(`${fixtures}/global_it_eaches.example`);
 
-      const filteredParseResult = simplifiedParseResult(parseResult);
-      expect(filteredParseResult).toMatchObject({
+      assertParseResultSimple(parseResult, {
         itBlocks: [
           {
             name: 'works with old functions',
@@ -479,16 +490,19 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
           }
         ],
         describeBlocks: [
+          // No describes
         ]
       });
     });
 
     it('For the simplest describe.each cases', () => {
-      const parseResult = parse(`${fixtures}/global_describe_eaches.example`);
+      const parseResult = parse(`${fixtures}/describe_eaches.example`);
 
-      const filteredParseResult = simplifiedParseResult(parseResult);
-      expect(filteredParseResult).toMatchObject({
+      assertParseResultSimple(parseResult, {
         itBlocks: [
+          // No tests
+        ],
+        describeBlocks: [
           {
             name: 'works with old functions',
             start: { line: 2, column: 1 },
@@ -528,14 +542,142 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
             name: 'works with describe.concurrent.skip',
             start: { line: 30, column: 1 },
             end: { line: 32, column: 3 }
+          }
+        ]
+      });
+    });
+    it('For nested cases', () => {
+      const parseResult = parse(`${fixtures}/nested_eaches.example`);
+
+      assertParseResultSimple(parseResult, {
+        itBlocks: [
+          {
+            name: 'it.each 1',
+            start: { line: 2, column: 3 },
+            end: { line: 3, column: 5 }
+          },
+          {
+            name: 'it.each 2',
+            start: { line: 4, column: 3 },
+            end: { line: 5, column: 5 }
+          },
+          {
+            name: 'it.each 3',
+            start: { line: 9, column: 3 },
+            end: { line: 10, column: 5 }
+          },
+          {
+            name: 'works with old functions',
+            start: { line: 14, column: 3 },
+            end: { line: 15, column: 5 }
           },
           {
             name: 'works with fdescribe',
-            start: { line: 34, column: 1 },
-            end: { line: 36, column: 3 }
+            start: { line: 19, column: 3 },
+            end: { line: 20, column: 5 }
+          },
+          {
+            name: 'works with describe.only',
+            start: { line: 24, column: 3 },
+            end: { line: 25, column: 5 }
+          },
+          {
+            name: 'works with describe.each',
+            start: { line: 29, column: 3 },
+            end: { line: 30, column: 5 }
+          },
+          {
+            name: 'works with inner describe',
+            start: { line: 35, column: 5 },
+            end: { line: 36, column: 7 }
+          },
+          {
+            name: 'works with inner describe.each',
+            start: { line: 39, column: 5 },
+            end: { line: 40, column: 7 }
+          },
+          {
+            name: 'normal it with inner describe.each',
+            start: { line: 41, column: 5 },
+            end: { line: 42, column: 7 }
+          },
+          {
+            name: 'works with outer describe.each',
+            start: { line: 48, column: 5 },
+            end: { line: 49, column: 7 }
+          },
+          {
+            name: 'normal it with outer describe.each',
+            start: { line: 50, column: 5 },
+            end: { line: 51, column: 7 }
+          },
+          {
+            name: 'works with inner and outer describe.each',
+            start: { line: 54, column: 5 },
+            end: { line: 55, column: 7 }
+          },
+          {
+            name: 'normal it with inner and outer describe.each',
+            start: { line: 56, column: 5 },
+            end: { line: 57, column: 7 }
           }
         ],
         describeBlocks: [
+          {
+            name: 'some context',
+            start: { line: 1, column: 1 },
+            end: { line: 6, column: 3 }
+          },
+          {
+            name: 'some other context',
+            start: { line: 8, column: 1 },
+            end: { line: 11, column: 3 }
+          },
+          {
+            name: 'with old functions',
+            start: { line: 13, column: 1 },
+            end: { line: 16, column: 3 }
+          },
+          {
+            name: 'with describe.only',
+            start: { line: 23, column: 1 },
+            end: { line: 26, column: 3 }
+          },
+          {
+            name: 'with describe.each',
+            start: { line: 28, column: 1 },
+            end: { line: 31, column: 3 }
+          },
+          {
+            name: 'outer',
+            start: { line: 33, column: 1 },
+            end: { line: 44, column: 3 }
+          },
+          {
+            name: 'inner',
+            start: { line: 34, column: 3 },
+            end: { line: 37, column: 5 }
+          },
+          {
+            name: 'inner',
+            start: { line: 38, column: 3 },
+            end: { line: 43, column: 5 }
+          },
+          {
+            name: 'outer describe.each',
+            start: { line: 46, column: 1 },
+            end: { line: 59, column: 3 }
+          },
+          {
+            name: 'inner',
+            start: { line: 47, column: 3 },
+            end: { line: 52, column: 5 }
+          },
+          {
+            name: 'inner',
+            start: { line: 53, column: 3 },
+            end: { line: 58, column: 5 }
+          }
         ]
       });
     });

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -447,6 +447,75 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       assertBlock2(itBlock, 2, 7, 6, 9, 'each test %p');
       assertNameInfo(itBlock, 'each test %p', 3, 10, 3, 21);
     });
+
+    it('For tagged template syntax', () => {
+      const parseResult = parse(`${fixtures}/each_tagged_templates.example`);
+
+      expect(parseResult).toMatchObject({
+        itBlocks: [
+          {
+            name: 'works with global tagged-template it.each',
+            start: { line: 1, column: 1 },
+            end: { line: 8, column: 3 }
+          },
+          {
+            name: 'works with global tagged-template test.each',
+            start: { line: 10, column: 1 },
+            end: { line: 17, column: 3 }
+          },
+          {
+            name: 'works with it inside tagged-template describe.each',
+            start: { line: 25, column: 3 },
+            end: { line: 27, column: 5 }
+          },
+          {
+            name: 'works with test inside tagged-template describe.each',
+            start: { line: 29, column: 3 },
+            end: { line: 31, column: 5 }
+          },
+          {
+            name: 'works with tagged-template it.each inside normal describe',
+            start: { line: 35, column: 3 },
+            end: { line: 42, column: 5 }
+          },
+          {
+            name: 'works with tagged-template test.each inside normal describe',
+            start: { line: 44, column: 3 },
+            end: { line: 51, column: 5 }
+          },
+          {
+            name: 'works with tagged-template it.each inside tagged-template describe.each',
+            start: { line: 59, column: 3 },
+            end: { line: 65, column: 5 }
+          },
+          {
+            name: 'works with tagged-template test.each inside tagged-template describe.each',
+            start: { line: 67, column: 3 },
+            end: { line: 73, column: 5 }
+          },
+        ],
+        describeBlocks: [
+          {
+            name: 'tagged describe.each',
+            start: { line: 19, column: 1 },
+            end: { line: 32, column: 3 }
+          },
+          {
+            name: 'normal describe',
+            start: { line: 34, column: 1 },
+            end: { line: 52, column: 3 }
+          },
+          {
+            name: 'tagged describe.each 2',
+            start: { line: 54, column: 1 },
+            end: { line: 74, column: 3 }
+          }
+        ]
+      });
+      // Make sure there are no extras
+      expect(parseResult.itBlocks.length).toBe(8);
+      expect(parseResult.describeBlocks.length).toBe(3);
+    });
   });
   describe('typescript specific', () => {
     it('parser should not crash on ArrowFunctionExpression', () => {

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -385,6 +385,52 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       assertBlock2(itBlock, 2, 7, 4, 9, 'each test %p');
       assertNameInfo(itBlock, 'each test %p', 2, 33, 2, 44);
     });
+    
+    it('For the simplest it.each cases', () => {
+      const data = parse(`${fixtures}/global_it_eaches.example`);
+
+      expect(data.itBlocks.length).toEqual(8);
+
+      const firstIt = data.itBlocks[0];
+      expect(firstIt.name).toEqual('works with old functions');
+      expect(firstIt.start).toEqual({column: 1, line: 2});
+      expect(firstIt.end).toEqual({column: 3, line: 4});
+
+      const secondIt = data.itBlocks[1];
+      expect(secondIt.name).toEqual('works with new functions');
+      expect(secondIt.start).toEqual({column: 1, line: 6});
+      expect(secondIt.end).toEqual({column: 3, line: 8});
+
+      const thirdIt = data.itBlocks[2];
+      expect(thirdIt.name).toEqual('works with flow functions');
+      expect(thirdIt.start).toEqual({column: 1, line: 10});
+      expect(thirdIt.end).toEqual({column: 3, line: 12});
+
+      const fourthIt = data.itBlocks[2];
+      expect(fourthIt.name).toEqual('works with flow functions');
+      expect(fourthIt.start).toEqual({column: 1, line: 10});
+      expect(fourthIt.end).toEqual({column: 3, line: 12});
+
+      const fifthIt = data.itBlocks[4];
+      expect(fifthIt.name).toEqual('works with it.only');
+      expect(fifthIt.start).toEqual({column: 1, line: 18});
+      expect(fifthIt.end).toEqual({column: 3, line: 20});
+
+      const sixthIt = data.itBlocks[5];
+      expect(sixthIt.name).toEqual('works with fit');
+      expect(sixthIt.start).toEqual({column: 1, line: 22});
+      expect(sixthIt.end).toEqual({column: 3, line: 24});
+
+      const seventhIt = data.itBlocks[6];
+      expect(seventhIt.name).toEqual('works with test');
+      expect(seventhIt.start).toEqual({column: 1, line: 26});
+      expect(seventhIt.end).toEqual({column: 3, line: 28});
+
+      const eigthIt = data.itBlocks[7];
+      expect(eigthIt.name).toEqual('works with test.only');
+      expect(eigthIt.start).toEqual({column: 1, line: 30});
+      expect(eigthIt.end).toEqual({column: 3, line: 32});
+    });
     it('should be able to detect test.each with a bit different layout', () => {
       const data = `
       test.each(['a','b', 'c'])(

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -17,7 +17,7 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
     }
   };
   const assertBlock2 = (block, sl: number, sc: number, el: number, ec: number, name: ?string = null) =>
-    assertBlock(block, {column: sc, line: sl}, {column: ec, line: el}, name);
+    assertBlock(block, { column: sc, line: sl }, { column: ec, line: el }, name);
   describe('File parsing without throwing', () => {
     it('Should not throw', () => {
       expect(() => {
@@ -25,6 +25,21 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       }).not.toThrow();
     });
   });
+  /**
+   * Simplify parseResult to make diffing easier during failed tests
+   */
+  const simplifiedParseResult = (parseResult: ParseResult) => ({
+    itBlocks: parseResult.itBlocks.map(it => ({
+      name: it.name,
+      start: it.start,
+      end: it.end
+    })),
+    describeBlocks: parseResult.describeBlocks.map(describe => ({
+      name: describe.name,
+      start: describe.start,
+      end: describe.end
+    }))
+  })
 
   describe('File Parsing for it blocks', () => {
     it('For the simplest it cases', () => {
@@ -34,43 +49,43 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
 
       const firstIt = data.itBlocks[0];
       expect(firstIt.name).toEqual('works with old functions');
-      expect(firstIt.start).toEqual({column: 1, line: 2});
-      expect(firstIt.end).toEqual({column: 3, line: 4});
+      expect(firstIt.start).toEqual({ column: 1, line: 2 });
+      expect(firstIt.end).toEqual({ column: 3, line: 4 });
 
       const secondIt = data.itBlocks[1];
       expect(secondIt.name).toEqual('works with new functions');
-      expect(secondIt.start).toEqual({column: 1, line: 6});
-      expect(secondIt.end).toEqual({column: 3, line: 8});
+      expect(secondIt.start).toEqual({ column: 1, line: 6 });
+      expect(secondIt.end).toEqual({ column: 3, line: 8 });
 
       const thirdIt = data.itBlocks[2];
       expect(thirdIt.name).toEqual('works with flow functions');
-      expect(thirdIt.start).toEqual({column: 1, line: 10});
-      expect(thirdIt.end).toEqual({column: 3, line: 12});
+      expect(thirdIt.start).toEqual({ column: 1, line: 10 });
+      expect(thirdIt.end).toEqual({ column: 3, line: 12 });
 
       const fourthIt = data.itBlocks[2];
       expect(fourthIt.name).toEqual('works with flow functions');
-      expect(fourthIt.start).toEqual({column: 1, line: 10});
-      expect(fourthIt.end).toEqual({column: 3, line: 12});
+      expect(fourthIt.start).toEqual({ column: 1, line: 10 });
+      expect(fourthIt.end).toEqual({ column: 3, line: 12 });
 
       const fifthIt = data.itBlocks[4];
       expect(fifthIt.name).toEqual('works with it.only');
-      expect(fifthIt.start).toEqual({column: 1, line: 18});
-      expect(fifthIt.end).toEqual({column: 3, line: 20});
+      expect(fifthIt.start).toEqual({ column: 1, line: 18 });
+      expect(fifthIt.end).toEqual({ column: 3, line: 20 });
 
       const sixthIt = data.itBlocks[5];
       expect(sixthIt.name).toEqual('works with fit');
-      expect(sixthIt.start).toEqual({column: 1, line: 22});
-      expect(sixthIt.end).toEqual({column: 3, line: 24});
+      expect(sixthIt.start).toEqual({ column: 1, line: 22 });
+      expect(sixthIt.end).toEqual({ column: 3, line: 24 });
 
       const seventhIt = data.itBlocks[6];
       expect(seventhIt.name).toEqual('works with test');
-      expect(seventhIt.start).toEqual({column: 1, line: 26});
-      expect(seventhIt.end).toEqual({column: 3, line: 28});
+      expect(seventhIt.start).toEqual({ column: 1, line: 26 });
+      expect(seventhIt.end).toEqual({ column: 3, line: 28 });
 
       const eigthIt = data.itBlocks[7];
       expect(eigthIt.name).toEqual('works with test.only');
-      expect(eigthIt.start).toEqual({column: 1, line: 30});
-      expect(eigthIt.end).toEqual({column: 3, line: 32});
+      expect(eigthIt.start).toEqual({ column: 1, line: 30 });
+      expect(eigthIt.end).toEqual({ column: 3, line: 32 });
     });
 
     it('For its inside describes', () => {
@@ -80,33 +95,33 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
 
       const firstIt = data.itBlocks[0];
       expect(firstIt.name).toEqual('1');
-      expect(firstIt.start).toEqual({column: 3, line: 2});
-      expect(firstIt.end).toEqual({column: 5, line: 3});
+      expect(firstIt.start).toEqual({ column: 3, line: 2 });
+      expect(firstIt.end).toEqual({ column: 5, line: 3 });
 
       const secondIt = data.itBlocks[1];
       expect(secondIt.name).toEqual('2');
-      expect(secondIt.start).toEqual({column: 3, line: 4});
-      expect(secondIt.end).toEqual({column: 5, line: 5});
+      expect(secondIt.start).toEqual({ column: 3, line: 4 });
+      expect(secondIt.end).toEqual({ column: 5, line: 5 });
 
       const thirdIt = data.itBlocks[2];
       expect(thirdIt.name).toEqual('3');
-      expect(thirdIt.start).toEqual({column: 3, line: 9});
-      expect(thirdIt.end).toEqual({column: 5, line: 10});
+      expect(thirdIt.start).toEqual({ column: 3, line: 9 });
+      expect(thirdIt.end).toEqual({ column: 5, line: 10 });
 
       const fourthIt = data.itBlocks[3];
       expect(fourthIt.name).toEqual('4');
-      expect(fourthIt.start).toEqual({column: 3, line: 14});
-      expect(fourthIt.end).toEqual({column: 5, line: 15});
+      expect(fourthIt.start).toEqual({ column: 3, line: 14 });
+      expect(fourthIt.end).toEqual({ column: 5, line: 15 });
 
       const fifthIt = data.itBlocks[4];
       expect(fifthIt.name).toEqual('5');
-      expect(fifthIt.start).toEqual({column: 3, line: 19});
-      expect(fifthIt.end).toEqual({column: 5, line: 20});
+      expect(fifthIt.start).toEqual({ column: 3, line: 19 });
+      expect(fifthIt.end).toEqual({ column: 5, line: 20 });
 
       const sixthIt = data.itBlocks[5];
       expect(sixthIt.name).toEqual('6');
-      expect(sixthIt.start).toEqual({column: 3, line: 24});
-      expect(sixthIt.end).toEqual({column: 5, line: 25});
+      expect(sixthIt.start).toEqual({ column: 3, line: 24 });
+      expect(sixthIt.end).toEqual({ column: 5, line: 25 });
     });
 
     // These tests act more like linters that we don't raise on
@@ -140,8 +155,8 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       expect(data.expects.length).toEqual(8);
 
       const firstExpect = data.expects[0];
-      expect(firstExpect.start).toEqual({column: 5, line: 13});
-      expect(firstExpect.end).toEqual({column: 36, line: 13});
+      expect(firstExpect.start).toEqual({ column: 5, line: 13 });
+      expect(firstExpect.end).toEqual({ column: 36, line: 13 });
     });
 
     it('finds Expects in a danger flow test file ', () => {
@@ -149,8 +164,8 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       expect(data.expects.length).toEqual(3);
 
       const thirdExpect = data.expects[2];
-      expect(thirdExpect.start).toEqual({column: 5, line: 33});
-      expect(thirdExpect.end).toEqual({column: 39, line: 33});
+      expect(thirdExpect.start).toEqual({ column: 5, line: 33 });
+      expect(thirdExpect.end).toEqual({ column: 39, line: 33 });
     });
 
     it('finds Expects in a metaphysics test file', () => {
@@ -169,7 +184,7 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       expect(data.describeBlocks.length).toEqual(4);
 
       const firstDescribe = data.describeBlocks[0];
-      assertBlock(firstDescribe, {column: 1, line: 10}, {column: 2, line: 20}, '.isCI');
+      assertBlock(firstDescribe, { column: 1, line: 10 }, { column: 2, line: 20 }, '.isCI');
     });
     it('finds test blocks within describe blocks', () => {
       const data = parse(`${fixtures}/dangerjs/travis-ci.example`);
@@ -228,8 +243,8 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       expect(dBlock.children.length).toBe(1);
       expect(t1.children.length).toBe(1);
 
-      assertBlock(t1, {column: 3, line: 2}, {column: 5, line: 4}, 'test has no expression either');
-      assertBlock(e1, {column: 5, line: 3}, {column: 25, line: 3});
+      assertBlock(t1, { column: 3, line: 2 }, { column: 5, line: 4 }, 'test has no expression either');
+      assertBlock(e1, { column: 5, line: 3 }, { column: 25, line: 3 });
     });
 
     test(`simple template literal`, () => {
@@ -240,9 +255,9 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       const t2 = dBlock.children[1];
       const t3 = dBlock.children[2];
 
-      assertBlock(t1, {column: 3, line: 8}, {column: 46, line: 8}, '${expression} up front');
-      assertBlock(t2, {column: 3, line: 9}, {column: 4, line: 10}, 'at the end ${expression}');
-      assertBlock(t3, {column: 3, line: 11}, {column: 5, line: 12}, 'mixed ${expression1} and ${expression2}');
+      assertBlock(t1, { column: 3, line: 8 }, { column: 46, line: 8 }, '${expression} up front');
+      assertBlock(t2, { column: 3, line: 9 }, { column: 4, line: 10 }, 'at the end ${expression}');
+      assertBlock(t3, { column: 3, line: 11 }, { column: 5, line: 12 }, 'mixed ${expression1} and ${expression2}');
     });
 
     test(`template literal with functions`, () => {
@@ -255,11 +270,11 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
 
       assertBlock(
         t1,
-        {column: 3, line: 16},
-        {column: 5, line: 18},
+        { column: 3, line: 16 },
+        { column: 5, line: 18 },
         'this ${test} calls ${JSON.stringfy(expression)} should still work'
       );
-      assertBlock(e1, {column: 5, line: 17}, {column: 31, line: 17});
+      assertBlock(e1, { column: 5, line: 17 }, { column: 31, line: 17 });
     });
 
     test(`multiline template literal`, () => {
@@ -272,12 +287,12 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
 
       assertBlock(
         t1,
-        {column: 3, line: 22},
-        {column: 5, line: 25},
+        { column: 3, line: 22 },
+        { column: 5, line: 25 },
         `this \${test} will span in
     multiple lines`
       );
-      assertBlock(e1, {column: 5, line: 24}, {column: 32, line: 24});
+      assertBlock(e1, { column: 5, line: 24 }, { column: 32, line: 24 });
     });
 
     test(`edge case: should not fail`, () => {
@@ -288,8 +303,8 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       expect(dBlock.children.length).toBe(2);
       expect(t1.children.length).toBe(1);
 
-      assertBlock(t1, {column: 3, line: 29}, {column: 5, line: 31}, '');
-      assertBlock(e1, {column: 5, line: 30}, {column: 30, line: 30});
+      assertBlock(t1, { column: 3, line: 29 }, { column: 5, line: 31 }, '');
+      assertBlock(e1, { column: 5, line: 30 }, { column: 30, line: 30 });
     });
   });
 
@@ -385,51 +400,87 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
       assertBlock2(itBlock, 2, 7, 4, 9, 'each test %p');
       assertNameInfo(itBlock, 'each test %p', 2, 33, 2, 44);
     });
-    
+
     it('For the simplest it.each cases', () => {
-      const data = parse(`${fixtures}/global_it_eaches.example`);
+      const parseResult = parse(`${fixtures}/global_it_eaches.example`);
 
-      expect(data.itBlocks.length).toEqual(8);
-
-      const firstIt = data.itBlocks[0];
-      expect(firstIt.name).toEqual('works with old functions');
-      expect(firstIt.start).toEqual({column: 1, line: 2});
-      expect(firstIt.end).toEqual({column: 3, line: 4});
-
-      const secondIt = data.itBlocks[1];
-      expect(secondIt.name).toEqual('works with new functions');
-      expect(secondIt.start).toEqual({column: 1, line: 6});
-      expect(secondIt.end).toEqual({column: 3, line: 8});
-
-      const thirdIt = data.itBlocks[2];
-      expect(thirdIt.name).toEqual('works with flow functions');
-      expect(thirdIt.start).toEqual({column: 1, line: 10});
-      expect(thirdIt.end).toEqual({column: 3, line: 12});
-
-      const fourthIt = data.itBlocks[2];
-      expect(fourthIt.name).toEqual('works with flow functions');
-      expect(fourthIt.start).toEqual({column: 1, line: 10});
-      expect(fourthIt.end).toEqual({column: 3, line: 12});
-
-      const fifthIt = data.itBlocks[4];
-      expect(fifthIt.name).toEqual('works with it.only');
-      expect(fifthIt.start).toEqual({column: 1, line: 18});
-      expect(fifthIt.end).toEqual({column: 3, line: 20});
-
-      const sixthIt = data.itBlocks[5];
-      expect(sixthIt.name).toEqual('works with fit');
-      expect(sixthIt.start).toEqual({column: 1, line: 22});
-      expect(sixthIt.end).toEqual({column: 3, line: 24});
-
-      const seventhIt = data.itBlocks[6];
-      expect(seventhIt.name).toEqual('works with test');
-      expect(seventhIt.start).toEqual({column: 1, line: 26});
-      expect(seventhIt.end).toEqual({column: 3, line: 28});
-
-      const eigthIt = data.itBlocks[7];
-      expect(eigthIt.name).toEqual('works with test.only');
-      expect(eigthIt.start).toEqual({column: 1, line: 30});
-      expect(eigthIt.end).toEqual({column: 3, line: 32});
+      const filteredParseResult = simplifiedParseResult(parseResult);
+      expect(filteredParseResult).toMatchObject({
+        itBlocks: [
+          {
+            name: 'works with old functions',
+            start: { line: 2, column: 1 },
+            end: { line: 4, column: 3 }
+          },
+          {
+            name: 'works with new functions',
+            start: { line: 6, column: 1 },
+            end: { line: 8, column: 3 }
+          },
+          {
+            name: 'works with flow functions',
+            start: { line: 10, column: 1 },
+            end: { line: 12, column: 3 }
+          },
+          {
+            name: 'works with JSX',
+            start: { line: 14, column: 1 },
+            end: { line: 16, column: 3 }
+          },
+          {
+            name: 'works with it.only',
+            start: { line: 18, column: 1 },
+            end: { line: 20, column: 3 }
+          },
+          {
+            name: 'works with it.concurrent',
+            start: { line: 22, column: 1 },
+            end: { line: 24, column: 3 }
+          },
+          {
+            name: 'works with it.concurrent.only',
+            start: { line: 26, column: 1 },
+            end: { line: 28, column: 3 }
+          },
+          {
+            name: 'works with it.concurrent.skip',
+            start: { line: 30, column: 1 },
+            end: { line: 32, column: 3 }
+          },
+          {
+            name: 'works with fit',
+            start: { line: 34, column: 1 },
+            end: { line: 36, column: 3 }
+          },
+          {
+            name: 'works with test',
+            start: { line: 38, column: 1 },
+            end: { line: 40, column: 3 }
+          },
+          {
+            name: 'works with test.only',
+            start: { line: 42, column: 1 },
+            end: { line: 44, column: 3 }
+          },
+          {
+            name: 'works with test.concurrent',
+            start: { line: 46, column: 1 },
+            end: { line: 48, column: 3 }
+          },
+          {
+            name: 'works with test.concurrent.only',
+            start: { line: 50, column: 1 },
+            end: { line: 52, column: 3 }
+          },
+          {
+            name: 'works with test.concurrent.skip',
+            start: { line: 54, column: 1 },
+            end: { line: 56, column: 3 }
+          },
+        ],
+        describeBlocks: [
+        ]
+      });
     });
     it('should be able to detect test.each with a bit different layout', () => {
       const data = `
@@ -451,7 +502,8 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
     it('For tagged template syntax', () => {
       const parseResult = parse(`${fixtures}/each_tagged_templates.example`);
 
-      expect(parseResult).toMatchObject({
+      const filteredParseResult = simplifiedParseResult(parseResult);
+      expect(filteredParseResult).toMatchObject({
         itBlocks: [
           {
             name: 'works with global tagged-template it.each',

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -476,7 +476,64 @@ function parserTests(parse: (file: string) => ParseResult, isTypescript = false)
             name: 'works with test.concurrent.skip',
             start: { line: 54, column: 1 },
             end: { line: 56, column: 3 }
+          }
+        ],
+        describeBlocks: [
+        ]
+      });
+    });
+
+    it('For the simplest describe.each cases', () => {
+      const parseResult = parse(`${fixtures}/global_describe_eaches.example`);
+
+      const filteredParseResult = simplifiedParseResult(parseResult);
+      expect(filteredParseResult).toMatchObject({
+        itBlocks: [
+          {
+            name: 'works with old functions',
+            start: { line: 2, column: 1 },
+            end: { line: 4, column: 3 }
           },
+          {
+            name: 'works with new functions',
+            start: { line: 6, column: 1 },
+            end: { line: 8, column: 3 }
+          },
+          {
+            name: 'works with flow functions',
+            start: { line: 10, column: 1 },
+            end: { line: 12, column: 3 }
+          },
+          {
+            name: 'works with JSX',
+            start: { line: 14, column: 1 },
+            end: { line: 16, column: 3 }
+          },
+          {
+            name: 'works with describe.only',
+            start: { line: 18, column: 1 },
+            end: { line: 20, column: 3 }
+          },
+          {
+            name: 'works with describe.concurrent',
+            start: { line: 22, column: 1 },
+            end: { line: 24, column: 3 }
+          },
+          {
+            name: 'works with describe.concurrent.only',
+            start: { line: 26, column: 1 },
+            end: { line: 28, column: 3 }
+          },
+          {
+            name: 'works with describe.concurrent.skip',
+            start: { line: 30, column: 1 },
+            end: { line: 32, column: 3 }
+          },
+          {
+            name: 'works with fdescribe',
+            start: { line: 34, column: 1 },
+            end: { line: 36, column: 3 }
+          }
         ],
         describeBlocks: [
         ]

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -30,19 +30,13 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
   const parseResult = new ParseResult(file);
   const [ast, _data] = _getASTfor(file, data, options);
 
-  const getRootOfTypeOrSelf = (node, type) => {
-    let rootForType = node;
-    while (rootForType[type]) {
-      rootForType = rootForType[type];
-    }
-    return rootForType;
-  };
-
-  const getRootCalleeOrSelf = node => getRootOfTypeOrSelf(node, 'callee');
-
-  const getRootTagOrSelf = node => getRootOfTypeOrSelf(node, 'tag');
-
-  const getRootObjectOrSelf = node => getRootOfTypeOrSelf(node, 'object');
+  const deepGet = (node, ...types: string[]) =>
+    types.reduce<BabelNode>((rootForType, type) => {
+      while (rootForType[type]) {
+        rootForType = rootForType[type];
+      }
+      return rootForType;
+    }, node);
 
   const updateNameInfo = (nBlock: NamedBlock, bNode: BabelNode) => {
     const arg = bNode.expression.arguments[0];
@@ -70,6 +64,7 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
       arg.loc.end.column - 1
     );
   };
+
   const updateNode = (node: ParsedNode, babylonNode: BabelNode) => {
     node.start = babylonNode.loc.start;
     node.end = babylonNode.loc.end;
@@ -88,11 +83,16 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
     nodeType === 'ArrowFunctionExpression' || nodeType === 'FunctionExpression';
 
   // Pull out the name of a CallExpression (describe/it)
-  // handle cases where it's a member expression (.only)
   const getNameForNode = node => {
     if (isFunctionCall(node) && node.expression.callee) {
-      const rootCallee = getRootCalleeOrSelf(node.expression);
-      const name = rootCallee.name || getRootObjectOrSelf(getRootTagOrSelf(rootCallee)).name;
+      // Get root callee in case it's a chain of higher-order functions (e.g. .each(table)(name, fn))
+      const rootCallee = deepGet(node.expression, 'callee');
+      const name =
+        rootCallee.name ||
+        // handle cases where it's a member expression (e.g .only or .concurrent.only)
+        deepGet(rootCallee, 'object').name ||
+        // handle cases where it's part of a tag (e.g. .each`table`)
+        deepGet(rootCallee, 'tag', 'object').name;
 
       return name;
     }

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -73,6 +73,18 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
   const isFunctionDeclaration = (nodeType: string) =>
     nodeType === 'ArrowFunctionExpression' || nodeType === 'FunctionExpression';
 
+  const getRootCallee = node => getRootOfType(node, 'callee');
+
+  const getRootObject = node => getRootOfType(node, 'object');
+
+  const getRootOfType = (node, type) => {
+    let rootForType = node;
+    while (rootForType[type]) {
+      rootForType = rootForType[type];
+    }
+    return rootForType;
+  };
+  
   // Pull out the name of a CallExpression (describe/it)
   // handle cases where it's a member expression (.only)
   const getNameForNode = node => {
@@ -84,18 +96,6 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
     }
     return undefined;
   };
-
-  const getRootCallee = node => getRootOfType(node, 'callee');
-
-  const getRootObject = node => getRootOfType(node, 'object');
-
-  const getRootOfType = (node, type) => {
-    let rootForType = node;
-    while(rootForType[type]) {
-      rootForType = rootForType[type];
-    }
-    return rootForType;
-  }
 
   // When given a node in the AST, does this represent
   // the start of an it/test block?

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -77,15 +77,25 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
   // handle cases where it's a member expression (.only)
   const getNameForNode = node => {
     if (isFunctionCall(node) && node && node.expression && node.expression.callee) {
-      const name =
-        node.expression.callee.name ||
-        node.expression.callee.object?.name ||
-        node.expression.callee.callee?.object?.name;
+      const rootCallee = getRootCallee(node.expression);
+      const name = rootCallee.name || getRootObject(rootCallee).name;
 
       return name;
     }
     return undefined;
   };
+
+  const getRootCallee = node => getRootOfType(node, 'callee');
+
+  const getRootObject = node => getRootOfType(node, 'object');
+
+  const getRootOfType = (node, type) => {
+    let rootForType = node;
+    while(rootForType[type]) {
+      rootForType = rootForType[type];
+    }
+    return rootForType;
+  }
 
   // When given a node in the AST, does this represent
   // the start of an it/test block?

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -88,7 +88,7 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
   // Pull out the name of a CallExpression (describe/it)
   // handle cases where it's a member expression (.only)
   const getNameForNode = node => {
-    if (isFunctionCall(node) && node && node.expression && node.expression.callee) {
+    if (isFunctionCall(node) && node.expression.callee) {
       const rootCallee = getRootCallee(node.expression);
       const name = rootCallee.name || getRootObject(rootCallee).name;
 


### PR DESCRIPTION
This PR enhances parsing of `it.each` and `describe.each` by allowing them to also be found when deeper in a property chain (e.g. `it.only.each`, `it.concurrent.only.each`, `describe.only.each`).  In addition, it also allows the **Tagged Template Literal** syntax of `it.each` and `describe.each` to be parsed.

It updates the logic that identifies `it` and `describe` blocks to walk up the callee chain to the root when there are multiple levels of callee (e.g. for `it.each(scenarios)(name, fn)`), and then to walk up the tag and object tree to the root (e.g. `each`->`only`->`concurrent`->`it`).

Jest API methods that should now be supported (from https://jestjs.io/docs/en/api):
* `describe.only.each(table)(name, fn)`
* `describe.skip.each(table)(name, fn)`
* ``describe.each`table`(name, fn)`` (and all variations above)
* `test.concurrent.each(table)(name, fn, timeout)`
* `test.concurrent.only.each(table)(name, fn)`
* `test.concurrent.skip.each(table)(name, fn)`
* `test.only.each(table)(name, fn)`
* `test.skip.each(table)(name, fn)`
* ``test.each`table`(name, fn)`` (and all variations above)

Fixes #53 
Fixes #59 