### PR TITLE
improve types and adding explicit args for Runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
-- Identify todo tests, which are distinct from pending/skip tests @pmcelhaney
+- Identify todo tests, which are distinct from pending/skip tests - @pmcelhaney
+- split exit and close runner event for correct/finer control; provide better event types. - @connectdotz
+- adding ability to pass explicit args for runner process - @connectdotz
 -->
 
 ### 28.1.0

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,16 +10,20 @@ import {ChildProcess} from 'child_process';
 import {Config as JestConfig} from '@jest/types';
 
 export interface Options {
-  createProcess?(
+  createProcess?: (
     workspace: ProjectWorkspace,
     args: string[],
-  ): ChildProcess;
+  ) => ChildProcess;
   noColor?: boolean;
   testNamePattern?: string;
   testFileNamePattern?: string;
   reporters?: string[];
+  // custom args if specified will supercede any auto arguement logic
+  args?: string[];
 }
 
+export type RunnerEvent = 'processClose' | 'processExit' | 'executableJSON' | 'executableStdErr' | 'executableOutput' | 'terminalError';
+export type DeprecatedRunnerEvent = 'debuggerProcessExit';
 export class Runner extends EventEmitter {
   constructor(workspace: ProjectWorkspace, options?: Options);
   watchMode: boolean;
@@ -27,6 +31,7 @@ export class Runner extends EventEmitter {
   start(watchMode?: boolean, watchAll?: boolean): void;
   closeProcess(): void;
   runJestWithUpdateForSnapshots(completion: () => void, args?: string[]): void;
+  on:(event: RunnerEvent|DeprecatedRunnerEvent, listener: (...args: any[]) => void) => this;
 }
 
 export interface JestSettings {

--- a/src/__tests__/runner.test.js
+++ b/src/__tests__/runner.test.js
@@ -299,6 +299,15 @@ describe('Runner', () => {
       const lastIndex = args.lastIndexOf('--reporters');
       expect(args[lastIndex + 1]).toBe(expected[1]);
     });
+    it('calls createProcess with explicit args supercede the auto arguments', () => {
+      const workspace: any = {};
+      const options = {args: ['--whatever']};
+      const sut = new Runner(workspace, options);
+      sut.start(false);
+
+      const args = (createProcess: any).mock.calls[0][1];
+      expect(args).toEqual(options.args);
+    });
   });
 
   describe('closeProcess', () => {
@@ -422,18 +431,26 @@ describe('Runner', () => {
       expect(error).toBeCalled();
     });
 
-    it('emits debuggerProcessExit when process exits', () => {
+    it('emits processExit when process exits', () => {
       const close = jest.fn();
-      runner.on('debuggerProcessExit', close);
+      runner.on('processExit', close);
       fakeProcess.emit('exit');
       expect(close).toBeCalled();
     });
 
-    it('emits debuggerProcessExit when process close', () => {
+    it('emits processExit when process close', () => {
       const close = jest.fn();
-      runner.on('debuggerProcessExit', close);
+      runner.on('processClose', close);
       fakeProcess.emit('close');
       expect(close).toBeCalled();
+    });
+    it('support to-be-deprecated debuggerProcessExit when process closes and exits', () => {
+      const close = jest.fn();
+      runner.on('debuggerProcessExit', close);
+      fakeProcess.emit('exit');
+      expect(close).toBeCalledTimes(1);
+      fakeProcess.emit('close');
+      expect(close).toBeCalledTimes(2);
     });
 
     it('should start jest process after killing the old process', () => {

--- a/src/types.js
+++ b/src/types.js
@@ -21,6 +21,8 @@ export type Options = {
   testNamePattern?: string,
   testFileNamePattern?: string,
   reporters?: string[],
+  // custom args if specified will supercede any auto arguement logic
+  args?: Array<string>,
 };
 
 /**


### PR DESCRIPTION
- split "close" and "exit" events that used to be combined "debuggerProcessExit " event, which should probably be deprecated in the future. 
- make the emitted event type explicit for typescript consumers
- adding the ability to pass explicit "args" for Runner that by-passing the jest test-result related argument logic. This is to enable the Runner to run the non-test-result jest process, such as getting the list of test files ("--listTests")