### PR TITLE
fix snapshot, runner, test_reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Bug-fixes within the same version aren't needed
 ## Master
 - Identify todo tests, which are distinct from pending/skip tests - @pmcelhaney
 - split exit and close runner event for correct/finer control; provide better event types. - @connectdotz
-- adding ability to pass explicit args for runner process - @connectdotz
+- adding ability to pass explicit, extra arguments and node_env for runner process - @connectdotz
+- fix snapshot parsing for flow and typescript files - @connectdotz
+
 -->
 
 ### 28.1.0

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,10 @@ import {ChildProcess} from 'child_process';
 import {Config as JestConfig} from '@jest/types';
 import { CoverageMap, CoverageMapData } from 'istanbul-lib-coverage';
 
+export interface RunArgs {
+  args: string[];
+  replace?: boolean; // default is false
+}
 export interface Options {
   createProcess?: (
     workspace: ProjectWorkspace,
@@ -19,10 +23,8 @@ export interface Options {
   testNamePattern?: string;
   testFileNamePattern?: string;
   reporters?: string[];
-  // extra args if specified will be appended to auto arguments
-  extraArgs?: string[];
-  // custom args if specified will supercede any auto arguement logic
-  args?: string[];
+  /** either to append or replace the Runner process arguments */
+  args?: RunArgs;
 }
 
 export type RunnerEvent = 'processClose' | 'processExit' | 'executableJSON' | 'executableStdErr' | 'executableOutput' | 'terminalError';

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@
 import {EventEmitter} from 'events';
 import {ChildProcess} from 'child_process';
 import {Config as JestConfig} from '@jest/types';
+import { CoverageMap, CoverageMapData } from 'istanbul-lib-coverage';
 
 export interface Options {
   createProcess?: (
@@ -18,6 +19,8 @@ export interface Options {
   testNamePattern?: string;
   testFileNamePattern?: string;
   reporters?: string[];
+  // extra args if specified will be appended to auto arguments
+  extraArgs?: string[];
   // custom args if specified will supercede any auto arguement logic
   args?: string[];
 }
@@ -62,6 +65,7 @@ export class ProjectWorkspace {
     outputFileSuffix?: string,
     collectCoverage?: boolean,
     debug?: boolean,
+    nodeEnv?: {[key: string]: string | undefined},
   );
   jestCommandLine: string;
   pathToConfig: string;
@@ -70,6 +74,7 @@ export class ProjectWorkspace {
   outputFileSuffix?: string;
   collectCoverage?: boolean;
   debug?: boolean;
+  nodeEnv?: {[key: string]: string | undefined};
 }
 
 export interface IParseResults {
@@ -144,6 +149,7 @@ export class TestReconciler {
     name: string,
   ): TestFileAssertionStatus | null;
   updateFileWithJestStatus(data: any): TestFileAssertionStatus[];
+  removeTestFile(fileName: string): void;
 }
 
 /**
@@ -213,7 +219,7 @@ export interface JestTotalResults {
   numPassedTests: number;
   numFailedTests: number;
   numPendingTests: number;
-  coverageMap: any;
+  coverageMap?: CoverageMapData;
   testResults: Array<JestFileResults>;
 }
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@babel/types": "^7.8.3",
     "@jest/types": "^26.6.2",
     "core-js": "^3.2.1",
-    "jest-snapshot": "^24.7.0"
+    "jest-snapshot": "^26.6.2"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/src/Process.js
+++ b/src/Process.js
@@ -28,8 +28,7 @@ export const createProcess = (workspace: ProjectWorkspace, args: Array<string>):
 
   // To use our own commands in create-react, we need to tell the command that
   // we're in a CI environment, or it will always append --watch
-  const {env} = process;
-  env.CI = 'true';
+  const env = {...process.env, ...(workspace.nodeEnv ?? {}), CI: 'true'};
 
   const spawnOptions = {
     cwd: workspace.rootPath,

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -50,7 +50,11 @@ export default class Runner extends EventEmitter {
     this._exited = false;
   }
 
-  _getArgs() {
+  _getArgs(): string[] {
+    if (this.options.args && this.options.args.replace) {
+      return this.options.args.args;
+    }
+
     // Handle the arg change on v18
     const belowEighteen = this.workspace.localJestMajorVersion < 18;
     const outputArg = belowEighteen ? '--jsonOutputFile' : '--outputFile';
@@ -78,8 +82,8 @@ export default class Runner extends EventEmitter {
         args.push('--reporters', reporter);
       });
     }
-    if (this.options.extraArgs) {
-      args.push(...this.options.extraArgs);
+    if (this.options.args) {
+      args.push(...this.options.args.args);
     }
     return args;
   }
@@ -92,7 +96,7 @@ export default class Runner extends EventEmitter {
     this.watchMode = watchMode;
     this.watchAll = watchAll;
 
-    const args = this.options.args ?? this._getArgs();
+    const args = this._getArgs();
     this.debugprocess = this._createProcess(this.workspace, args);
     this.debugprocess.stdout.on('data', (data: Buffer) => {
       this._parseOutput(data, false);

--- a/src/__tests__/parsers/babel_parser.test.js
+++ b/src/__tests__/parsers/babel_parser.test.js
@@ -7,7 +7,9 @@
  * @flow
  */
 
-const {parseJs} = require('../../parsers/babel_parser');
+const {parseOptions} = require('../../parsers/helper');
+const {parse} = require('../../parsers/babel_parser');
 const {parserTests} = require('../../../fixtures/parser_tests');
 
+const parseJs = (file: string, data?: string) => parse(file, data, parseOptions('always.js'));
 parserTests(parseJs);

--- a/src/__tests__/parsers/babel_typescript_parser.test.js
+++ b/src/__tests__/parsers/babel_typescript_parser.test.js
@@ -3,9 +3,13 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ * @flow
  */
 
-import {parseTs} from '../../parsers/babel_parser';
 import {parserTests} from '../../../fixtures/parser_tests';
 
+const {parseOptions} = require('../../parsers/helper');
+const {parse} = require('../../parsers/babel_parser');
+
+const parseTs = (file: string, data?: string) => parse(file, data, parseOptions('always.ts'));
 parserTests(parseTs, true);

--- a/src/__tests__/parsers/helper.test.js
+++ b/src/__tests__/parsers/helper.test.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as helper from '../../parsers/helper';
+
+jest.mock('../../parsers/babel_parser', () => {
+  return {parse: jest.fn()};
+});
+
+describe('supportedFileType', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('for .js or .jsx or .mjs file', () => {
+    const files = ['abc.js', 'abc.jsx', 'abc.mjs'];
+    files.forEach(file => {
+      expect(helper.supportedFileType(file)).toEqual('js');
+      jest.clearAllMocks();
+    });
+  });
+  describe('parseOption', () => {
+    it('js file should contain "flow" plugin', () => {
+      expect(helper.parseOptions('abc.js')).toEqual({plugins: [...helper.plugins, 'flow']});
+    });
+    it('ts file should contain "typescript" plugin', () => {
+      expect(helper.parseOptions('abc.ts')).toEqual({plugins: [...helper.plugins, 'typescript']});
+    });
+    describe('for unrecognized file type', () => {
+      it('in strict mode, throw error', () => {
+        expect(() => helper.parseOptions('abc.json', true)).toThrow();
+      });
+      it('in non-strict mode, use js options', () => {
+        expect(helper.parseOptions('abc.json', false)).toEqual({plugins: [...helper.plugins, 'flow']});
+      });
+    });
+  });
+});

--- a/src/__tests__/process.test.js
+++ b/src/__tests__/process.test.js
@@ -70,6 +70,15 @@ describe('createProcess', () => {
 
     expect(spawn.mock.calls[0][2].env).toEqual(expected);
   });
+  it('allow customize node environment variable', () => {
+    const workspace: any = {
+      nodeEnv: {NODE_ENV: 'test', CI: 'false'},
+    };
+    const expected = Object.assign({}, process.env, workspace.nodeEnv, {CI: 'true'});
+    createProcess(workspace, []);
+
+    expect(spawn.mock.calls[0][2].env).toEqual(expected);
+  });
 
   it('sets the current working directory of the child process', () => {
     const workspace: any = {

--- a/src/__tests__/project_workspace.test.js
+++ b/src/__tests__/project_workspace.test.js
@@ -105,4 +105,19 @@ describe('setup', () => {
     const {pathToJest} = instance;
     expect(global.console.warn).toBeCalledTimes(2);
   });
+  it('allow passing nodeEnv', () => {
+    const config = {
+      jestCommandLine: 'jestCommandLine',
+      localJestMajorVersion: 1000,
+      rootPath: 'rootPath',
+      collectCoverage: false,
+      debug: true,
+      outputFileSuffix: 'suffix',
+      nodeEnv: {NODE_ENV: 'production'},
+    };
+
+    const instance = createProjectWorkspace(config);
+
+    expect(instance.nodeEnv).toBe(config.nodeEnv);
+  });
 });

--- a/src/__tests__/runner.test.js
+++ b/src/__tests__/runner.test.js
@@ -308,6 +308,14 @@ describe('Runner', () => {
       const args = (createProcess: any).mock.calls[0][1];
       expect(args).toEqual(options.args);
     });
+    it('calls createProcess with extra args appended to the auto arguments', () => {
+      const workspace: any = {};
+      const options = {noColor: true, extraArgs: ['--whatever']};
+      const sut = new Runner(workspace, options);
+      sut.start(false);
+
+      expect(createProcess).toBeCalledWith(workspace, expect.arrayContaining(['--no-color', '--whatever']));
+    });
   });
 
   describe('closeProcess', () => {
@@ -434,15 +442,15 @@ describe('Runner', () => {
     it('emits processExit when process exits', () => {
       const close = jest.fn();
       runner.on('processExit', close);
-      fakeProcess.emit('exit');
-      expect(close).toBeCalled();
+      fakeProcess.emit('exit', 0, null);
+      expect(close).toBeCalledWith(0, null);
     });
 
     it('emits processExit when process close', () => {
       const close = jest.fn();
       runner.on('processClose', close);
-      fakeProcess.emit('close');
-      expect(close).toBeCalled();
+      fakeProcess.emit('close', null, 'SIGKILL');
+      expect(close).toBeCalledWith(null, 'SIGKILL');
     });
     it('support to-be-deprecated debuggerProcessExit when process closes and exits', () => {
       const close = jest.fn();

--- a/src/__tests__/runner.test.js
+++ b/src/__tests__/runner.test.js
@@ -299,22 +299,20 @@ describe('Runner', () => {
       const lastIndex = args.lastIndexOf('--reporters');
       expect(args[lastIndex + 1]).toBe(expected[1]);
     });
-    it('calls createProcess with explicit args supercede the auto arguments', () => {
-      const workspace: any = {};
-      const options = {args: ['--whatever']};
-      const sut = new Runner(workspace, options);
-      sut.start(false);
+    describe('RunArgs', () => {
+      it.each`
+        runArgs                                   | containedArgs
+        ${{args: ['--whatever']}}                 | ${['--no-color', '--whatever']}
+        ${{args: ['--whatever'], replace: false}} | ${['--no-color', '--whatever']}
+        ${{args: ['--whatever'], replace: true}}  | ${['--whatever']}
+      `('supports $runArg', ({runArgs, containedArgs}) => {
+        const workspace: any = {};
+        const options = {noColor: true, args: runArgs};
+        const sut = new Runner(workspace, options);
+        sut.start(false);
 
-      const args = (createProcess: any).mock.calls[0][1];
-      expect(args).toEqual(options.args);
-    });
-    it('calls createProcess with extra args appended to the auto arguments', () => {
-      const workspace: any = {};
-      const options = {noColor: true, extraArgs: ['--whatever']};
-      const sut = new Runner(workspace, options);
-      sut.start(false);
-
-      expect(createProcess).toBeCalledWith(workspace, expect.arrayContaining(['--no-color', '--whatever']));
+        expect(createProcess).toBeCalledWith(workspace, expect.arrayContaining(containedArgs));
+      });
     });
   });
 

--- a/src/__tests__/test_reconciler.test.js
+++ b/src/__tests__/test_reconciler.test.js
@@ -187,6 +187,17 @@ Expected value to be falsy, instead received
       });
     });
   });
+  it('can remove test file from cache', () => {
+    parser = new TestReconciler();
+    results = reconcilerWithFile(parser, 'failing_jest_json.json');
+
+    expect(results.length).toEqual(5);
+    const {file} = results[1];
+    expect(parser.assertionsForTestFile(file)).not.toBeNull();
+
+    parser.removeTestFile(file);
+    expect(parser.assertionsForTestFile(file)).toBeNull();
+  });
 });
 
 describe('Terse Messages', () => {

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -14,6 +14,7 @@ import {File as BabelFile, Node as BabelNode} from '@babel/types';
 import * as parser from '@babel/parser';
 import type {ParsedNodeType} from './parser_nodes';
 import {NamedBlock, ParsedRange, ParseResult, ParsedNode} from './parser_nodes';
+import {parseOptions} from './helper';
 
 export const UNRESOLVED_FUNCTION_NAME = '__function__';
 export const UNSUPPORTED_TEST_NAME = '__unsupported__';
@@ -25,7 +26,7 @@ const _getASTfor = (file: string, data: ?string, options: ?parser.ParserOptions)
 };
 
 export const getASTfor = (file: string, data: ?string): BabelFile => {
-  const [bFile] = _getASTfor(file, data);
+  const [bFile] = _getASTfor(file, data, parseOptions(file));
   return bFile;
 };
 
@@ -198,36 +199,3 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
 
   return parseResult;
 };
-
-export const plugins = [
-  'asyncGenerators',
-  'bigInt',
-  'classPrivateMethods',
-  'classPrivateProperties',
-  'classProperties',
-  'doExpressions',
-  'dynamicImport',
-  'estree',
-  'exportDefaultFrom',
-  'exportNamespaceFrom', // deprecated
-  'functionBind',
-  'functionSent',
-  'importMeta',
-  'jsx',
-  'logicalAssignment',
-  'nullishCoalescingOperator',
-  'numericSeparator',
-  'objectRestSpread',
-  'optionalCatchBinding',
-  'optionalChaining',
-  'partialApplication',
-  'throwExpressions',
-  'topLevelAwait',
-  ['decorators', {decoratorsBeforeExport: true}],
-  ['pipelineOperator', {proposal: 'smart'}],
-];
-
-// Its not possible to use the parser with flow and typescript active at the same time
-export const parseJs = (file: string, data: ?string): ParseResult => parse(file, data, {plugins: [...plugins, 'flow']});
-export const parseTs = (file: string, data: ?string): ParseResult =>
-  parse(file, data, {plugins: [...plugins, 'typescript']});

--- a/src/parsers/helper.ts
+++ b/src/parsers/helper.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {ParserOptions, ParserPlugin} from '@babel/parser';
+
+/**
+ * determine if the file is a typescript (ts), javascript (js) otherwise returns undefined.
+ * @param filepath
+ * @returns 'js'|'ts' or undefined
+ */
+export const supportedFileType = (filePath: string): 'ts' | 'js' | undefined => {
+  if (filePath.match(/\.tsx?$/)) {
+    return 'ts';
+  }
+  if (filePath.match(/\.m?jsx?$/)) {
+    return 'js';
+  }
+  return undefined;
+};
+
+export const plugins: ParserPlugin[] = [
+  'asyncGenerators',
+  'bigInt',
+  'classPrivateMethods',
+  'classPrivateProperties',
+  'classProperties',
+  'doExpressions',
+  'dynamicImport',
+  'estree',
+  'exportDefaultFrom',
+  'exportNamespaceFrom', // deprecated
+  'functionBind',
+  'functionSent',
+  'importMeta',
+  'jsx',
+  'logicalAssignment',
+  'nullishCoalescingOperator',
+  'numericSeparator',
+  'objectRestSpread',
+  'optionalCatchBinding',
+  'optionalChaining',
+  'partialApplication',
+  'throwExpressions',
+  'topLevelAwait',
+  ['decorators', {decoratorsBeforeExport: true}],
+  ['pipelineOperator', {proposal: 'smart'}],
+];
+
+export const parseOptions = (filePath: string, strictMode = false): ParserOptions | null => {
+  const fileType = supportedFileType(filePath);
+  if (fileType === 'ts') {
+    return {plugins: [...plugins, 'typescript']};
+  }
+  const jsOptions: ParserOptions = {plugins: [...plugins, 'flow']};
+  if (fileType === 'js') {
+    return jsOptions;
+  }
+
+  // unexpected file extension, for backward compatibility, will use js parser
+  if (strictMode) {
+    throw new TypeError(`unable to find parser options for unrecognized file extension: ${filePath}`);
+  }
+
+  return jsOptions;
+};

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -7,7 +7,8 @@
  */
 
 import {ParseResult} from './parser_nodes';
-import {parseJs, parseTs} from './babel_parser';
+import {parse as babelParser} from './babel_parser';
+import {parseOptions} from './helper';
 
 /**
  * parse the test file by selecting proper parser based on the file extension.
@@ -15,16 +16,5 @@ import {parseJs, parseTs} from './babel_parser';
  * exception will be throw should the underlying parse failed.
  */
 export default function parse(filePath: string, serializedData?: string, strictMode = false): ParseResult {
-  if (filePath.match(/\.tsx?$/)) {
-    return parseTs(filePath, serializedData);
-  }
-  if (filePath.match(/\.m?jsx?$/)) {
-    return parseJs(filePath, serializedData);
-  }
-
-  // unexpected file extension, for backward compatibility, will use js parser
-  if (strictMode) {
-    throw new TypeError(`unable to find parser for unrecognized file extension: ${filePath}`);
-  }
-  return parseJs(filePath, serializedData);
+  return babelParser(filePath, serializedData, parseOptions(filePath, strictMode));
 }

--- a/src/project_workspace.ts
+++ b/src/project_workspace.ts
@@ -14,6 +14,7 @@ export interface ProjectWorkspaceConfig {
   outputFileSuffix?: string;
   collectCoverage?: boolean;
   debug?: boolean;
+  nodeEnv?: {[key: string]: string | undefined};
 }
 
 /**
@@ -93,6 +94,11 @@ export default class ProjectWorkspace {
    */
   outputFileSuffix?: string;
 
+  /**
+   * optional additional node env variables
+   */
+  nodeEnv?: {[key: string]: string | undefined};
+
   constructor(
     rootPath: string,
     jestCommandLine: string,
@@ -100,7 +106,8 @@ export default class ProjectWorkspace {
     localJestMajorVersion: number,
     outputFileSuffix?: string,
     collectCoverage?: boolean,
-    debug?: boolean
+    debug?: boolean,
+    nodeEnv?: {[key: string]: string | undefined}
   ) {
     this.rootPath = rootPath;
     this.jestCommandLine = jestCommandLine;
@@ -109,6 +116,7 @@ export default class ProjectWorkspace {
     this.outputFileSuffix = outputFileSuffix ? outputFileSuffix.replace(/[^a-z0-9]/gi, '_').toLowerCase() : undefined;
     this.collectCoverage = collectCoverage;
     this.debug = debug;
+    this.nodeEnv = nodeEnv;
   }
 }
 
@@ -126,6 +134,7 @@ export const createProjectWorkspace = (config: ProjectWorkspaceConfig): ProjectW
     config.localJestMajorVersion,
     config.outputFileSuffix,
     config.collectCoverage,
-    config.debug
+    config.debug,
+    config.nodeEnv
   );
 };

--- a/src/test_reconciler.js
+++ b/src/test_reconciler.js
@@ -50,6 +50,14 @@ export default class TestReconciler {
     return statusList;
   }
 
+  /**
+   * remove jest status of the test file from the cached results
+   * @param {string} fileName
+   */
+  removeTestFile(fileName: string) {
+    delete this.fileStatuses[fileName];
+  }
+
   // A failed test also contains the stack trace for an `expect`
   // we don't get this as structured data, but what we get
   // is useful enough to make it for ourselves

--- a/src/types.js
+++ b/src/types.js
@@ -21,6 +21,8 @@ export type Options = {
   testNamePattern?: string,
   testFileNamePattern?: string,
   reporters?: string[],
+  // extra args if specified will be appended to auto arguments
+  extraArgs?: Array<string>,
   // custom args if specified will supercede any auto arguement logic
   args?: Array<string>,
 };

--- a/src/types.js
+++ b/src/types.js
@@ -15,16 +15,20 @@ export type Location = {
   line: number,
 };
 
+export type RunArgs = {
+  args: Array<string>,
+  replace?: boolean, // default is false
+};
+
 export type Options = {
   createProcess?: (workspace: ProjectWorkspace, args: Array<string>) => ChildProcess,
   noColor?: boolean,
   testNamePattern?: string,
   testFileNamePattern?: string,
   reporters?: string[],
-  // extra args if specified will be appended to auto arguments
-  extraArgs?: Array<string>,
-  // custom args if specified will supercede any auto arguement logic
-  args?: Array<string>,
+
+  /** either to append or replace the Runner process arguments */
+  args?: RunArgs,
 };
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
       "noImplicitAny": false,                   /* Raise error on expressions and declarations with an implied 'any' type. */    
       "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     },
-    "include": ["./src/**/*.ts"],
+    "include": ["./src/**/*.ts", "src/__tests__/parsers/helper.test.js"],
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,15 +1062,6 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@jest/console@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
-  integrity sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==
-  dependencies:
-    "@jest/source-map" "^24.9.0"
-    chalk "^2.0.1"
-    slash "^2.0.0"
-
 "@jest/console@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-26.6.2.tgz#4e04bc464014358b03ab4937805ee36a0aeb98f2"
@@ -1180,15 +1171,6 @@
   optionalDependencies:
     node-notifier "^8.0.0"
 
-"@jest/source-map@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-24.9.0.tgz#0e263a94430be4b41da683ccc1e6bffe2a191714"
-  integrity sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==
-  dependencies:
-    callsites "^3.0.0"
-    graceful-fs "^4.1.15"
-    source-map "^0.6.0"
-
 "@jest/source-map@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-26.6.2.tgz#29af5e1e2e324cafccc936f218309f54ab69d535"
@@ -1197,15 +1179,6 @@
     callsites "^3.0.0"
     graceful-fs "^4.2.4"
     source-map "^0.6.0"
-
-"@jest/test-result@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.9.0.tgz#11796e8aa9dbf88ea025757b3152595ad06ba0ca"
-  integrity sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==
-  dependencies:
-    "@jest/console" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/istanbul-lib-coverage" "^2.0.0"
 
 "@jest/test-result@^26.6.2":
   version "26.6.2"
@@ -1248,15 +1221,6 @@
     slash "^3.0.0"
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
-
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
 
 "@jest/types@^26.6.2":
   version "26.6.2"
@@ -1461,14 +1425,6 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^1.1.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
-  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "*"
-    "@types/istanbul-lib-report" "*"
-
 "@types/istanbul-reports@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
@@ -1506,11 +1462,6 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.6.tgz#f4b1efa784e8db479cdb8b14403e2144b1e9ff03"
   integrity sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==
 
-"@types/stack-utils@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
-  integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
-
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
@@ -1520,13 +1471,6 @@
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
-
-"@types/yargs@^13.0.0":
-  version "13.0.9"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.9.tgz#44028e974343c7afcf3960f1a2b1099c39a7b5e1"
-  integrity sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.12"
@@ -1652,7 +1596,7 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -1993,13 +1937,6 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browser-resolve@^1.11.3:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
-  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
-  dependencies:
-    resolve "1.1.7"
-
 browserslist@^4.11.1, browserslist@^4.8.5:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.12.0.tgz#06c6d5715a1ede6c51fc39ff67fd647f740b656d"
@@ -2082,9 +2019,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001043:
-  version "1.0.30001062"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001062.tgz#d814b648338504b315222ace6f1a533d9a55e390"
-  integrity sha512-ei9ZqeOnN7edDrb24QfJ0OZicpEbsWxv7WusOiQGz/f2SfvBgHHbOEwBJ8HKGVSyx8Z6ndPjxzR6m0NQq+0bfw==
+  version "1.0.30001192"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001192.tgz"
+  integrity sha512-63OrUnwJj5T1rUmoyqYTdRWBqFFxZFlyZnRRjDR8NSUQFB6A+j/uBORU/SyJ5WzDLg4SPiZH40hQCBNdZ/jmAw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2578,11 +2515,6 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-diff-sequences@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
-  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
-
 diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
@@ -2664,7 +2596,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.5:
+es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
   version "1.17.5"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
   integrity sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
@@ -3004,18 +2936,6 @@ expand-tilde@^2.0.2:
   integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
   dependencies:
     homedir-polyfill "^1.0.1"
-
-expect@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
-  integrity sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-styles "^3.2.0"
-    jest-get-type "^24.9.0"
-    jest-matcher-utils "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-regex-util "^24.9.0"
 
 expect@^26.6.2:
   version "26.6.2"
@@ -3419,7 +3339,7 @@ globrex@^0.1.1:
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -4064,16 +3984,6 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
-  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
-  dependencies:
-    chalk "^2.0.1"
-    diff-sequences "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
-
 jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
@@ -4126,11 +4036,6 @@ jest-environment-node@^26.6.2:
     "@types/node" "*"
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
-
-jest-get-type@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
-  integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
 
 jest-get-type@^26.3.0:
   version "26.3.0"
@@ -4190,16 +4095,6 @@ jest-leak-detector@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
-jest-matcher-utils@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
-  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
-  dependencies:
-    chalk "^2.0.1"
-    jest-diff "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
-
 jest-matcher-utils@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
@@ -4209,20 +4104,6 @@ jest-matcher-utils@^26.6.2:
     jest-diff "^26.6.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
-
-jest-message-util@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.9.0.tgz#527f54a1e380f5e202a8d1149b0ec872f43119e3"
-  integrity sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/stack-utils" "^1.0.1"
-    chalk "^2.0.1"
-    micromatch "^3.1.10"
-    slash "^2.0.0"
-    stack-utils "^1.0.1"
 
 jest-message-util@^26.6.2:
   version "26.6.2"
@@ -4247,20 +4128,10 @@ jest-mock@^26.6.2:
     "@jest/types" "^26.6.2"
     "@types/node" "*"
 
-jest-pnp-resolver@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
-  integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
-
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
   integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
-
-jest-regex-util@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.9.0.tgz#c13fb3380bde22bf6575432c493ea8fe37965636"
-  integrity sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==
 
 jest-regex-util@^26.0.0:
   version "26.0.0"
@@ -4275,17 +4146,6 @@ jest-resolve-dependencies@^26.6.3:
     "@jest/types" "^26.6.2"
     jest-regex-util "^26.0.0"
     jest-snapshot "^26.6.2"
-
-jest-resolve@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-24.9.0.tgz#dff04c7687af34c4dd7e524892d9cf77e5d17321"
-  integrity sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    browser-resolve "^1.11.3"
-    chalk "^2.0.1"
-    jest-pnp-resolver "^1.2.1"
-    realpath-native "^1.1.0"
 
 jest-resolve@^26.6.2:
   version "26.6.2"
@@ -4367,25 +4227,6 @@ jest-serializer@^26.6.2:
   dependencies:
     "@types/node" "*"
     graceful-fs "^4.2.4"
-
-jest-snapshot@^24.7.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-24.9.0.tgz#ec8e9ca4f2ec0c5c87ae8f925cf97497b0e951ba"
-  integrity sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==
-  dependencies:
-    "@babel/types" "^7.0.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
-    expect "^24.9.0"
-    jest-diff "^24.9.0"
-    jest-get-type "^24.9.0"
-    jest-matcher-utils "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-resolve "^24.9.0"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    pretty-format "^24.9.0"
-    semver "^6.2.0"
 
 jest-snapshot@^26.6.2:
   version "26.6.2"
@@ -5253,14 +5094,6 @@ object.entries@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-object.getownpropertydescriptors@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
-  integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-
 object.pick@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
@@ -5611,16 +5444,6 @@ prettier@^1.17.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-pretty-format@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
-
 pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
@@ -5699,11 +5522,6 @@ query-string@^6.8.2:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
-react-is@^16.8.4:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
 react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
@@ -5771,13 +5589,6 @@ readline-sync@^1.4.9:
   version "1.4.10"
   resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
   integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
-
-realpath-native@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
-  integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
-  dependencies:
-    util.promisify "^1.0.0"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -5945,11 +5756,6 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
-
 resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.3.2:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
@@ -6088,7 +5894,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -6309,11 +6115,6 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
-
-stack-utils@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
-  integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
 stack-utils@^2.0.2:
   version "2.0.3"
@@ -6850,16 +6651,6 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
-util.promisify@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.1.tgz#6baf7774b80eeb0f7520d8b81d07982a59abbaee"
-  integrity sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.2"
-    has-symbols "^1.0.1"
-    object.getownpropertydescriptors "^2.1.0"
 
 uuid@^3.3.2:
   version "3.4.0"


### PR DESCRIPTION
 change summary
## typescript types
- fix typescript types for coverage  

## Runner
  - adding extra arguments for more granular control of the run process
  - allow passing node_env 
  - emit close and exit events separately
  
## test_reconciler
  - add API to remove file from cache
  
## snapshot
- fixes snapshot parsing for flow and typescript files
- refactor and clean up parser modules and tests
- upgrade "jest-snapshot" dependency
  