### PR TITLE
parser: add additional attributes and preserve describe/it block names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Bug-fixes within the same version aren't needed
 ## Master
 * convert `parser-test.js` to a true jest test: `babel-parser.test.ts` and convert to typescript. - @connectdotz
 * upgrade prettier and @babel/preset-typescript, fix lint errors. - @connectdotz
-* adding lastProperty and hasDynamicName attributes to NamedNode - @connectdotz
-* preserve test/describe block names regardless of its types, i.e. string or template-literal or function etc - @connectdotz
+* adding lastProperty and nameType attributes to NamedNode - @connectdotz
+* preserve test/describe block name argument instead of using a type-marker - @connectdotz
 -->
 
 ### 28.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Bug-fixes within the same version aren't needed
 ## Master
 * convert `parser-test.js` to a true jest test: `babel-parser.test.ts` and convert to typescript. - @connectdotz
 * upgrade prettier and @babel/preset-typescript, fix lint errors. - @connectdotz
+* adding lastProperty to NamedNode - @connectdotz
 -->
 
 ### 28.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Bug-fixes within the same version aren't needed
 ## Master
 * convert `parser-test.js` to a true jest test: `babel-parser.test.ts` and convert to typescript. - @connectdotz
 * upgrade prettier and @babel/preset-typescript, fix lint errors. - @connectdotz
-* adding lastProperty to NamedNode - @connectdotz
+* adding lastProperty and hasDynamicName attributes to NamedNode - @connectdotz
+* preserve test/describe block names regardless of its types, i.e. string or template-literal or function etc - @connectdotz
 -->
 
 ### 28.2.0

--- a/index.d.ts
+++ b/index.d.ts
@@ -128,15 +128,16 @@ export declare class ParsedNode {
 
 export declare class NamedBlock extends ParsedNode {
   name: string;
+  lastProperty?: string;
   nameRange: ParsedRange;
   constructor(type: ParsedNodeType, file: string, name?: string);
 }
 
 export declare class ItBlock extends NamedBlock {
-  constructor(file: string, name?: string);
+  constructor(file: string, name?: string, lastProperty?: string);
 }
 export declare class DescribeBlock extends NamedBlock {
-  constructor(file: string, name?: string);
+  constructor(file: string, name?: string, lastProperty?: string);
 }
 
 export declare class Expect extends ParsedNode {

--- a/index.d.ts
+++ b/index.d.ts
@@ -128,8 +128,9 @@ export declare class ParsedNode {
 
 export declare class NamedBlock extends ParsedNode {
   name: string;
-  lastProperty?: string;
   nameRange: ParsedRange;
+  lastProperty?: string;
+  hasDynamicName?: Boolean;
   constructor(type: ParsedNodeType, file: string, name?: string);
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@
 import {EventEmitter} from 'events';
 import {ChildProcess} from 'child_process';
 import {Config as JestConfig} from '@jest/types';
-import { CoverageMap, CoverageMapData } from 'istanbul-lib-coverage';
+import { CoverageMapData } from 'istanbul-lib-coverage';
 
 export interface RunArgs {
   args: string[];
@@ -125,12 +125,16 @@ export declare class ParsedNode {
   filter(f: (parsedNode: ParsedNode) => boolean): Array<ParsedNode>;
   addChild(type: ParsedNodeType): ParsedNode;
 }
-
 export declare class NamedBlock extends ParsedNode {
   name: string;
   nameRange: ParsedRange;
   lastProperty?: string;
-  hasDynamicName?: boolean;
+  /**
+   * type of the name, it's the babel Node["type"], such as "Literal", "TemplateLiteral" etc
+   *
+   * TODO babel parser currently returns "Literal" for the it/describe name argument, which is not part of its "type" definition, therefore declare a string type for now until it is fixed in babel.
+   * */
+  nameType?: string;
   constructor(type: ParsedNodeType, file: string, name?: string);
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,15 +130,15 @@ export declare class NamedBlock extends ParsedNode {
   name: string;
   nameRange: ParsedRange;
   lastProperty?: string;
-  hasDynamicName?: Boolean;
+  hasDynamicName?: boolean;
   constructor(type: ParsedNodeType, file: string, name?: string);
 }
 
 export declare class ItBlock extends NamedBlock {
-  constructor(file: string, name?: string, lastProperty?: string);
+  constructor(file: string, name?: string);
 }
 export declare class DescribeBlock extends NamedBlock {
-  constructor(file: string, name?: string, lastProperty?: string);
+  constructor(file: string, name?: string);
 }
 
 export declare class Expect extends ParsedNode {

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "typescript": "^3.8.2"
   },
   "dependencies": {
-    "@babel/parser": "^7.8.3",
+    "@babel/parser": "^7.14.4",
     "@babel/traverse": "^7.6.2",
-    "@babel/types": "^7.8.3",
+    "@babel/types": "^7.14.4",
     "@jest/types": "^26.6.2",
     "core-js": "^3.2.1",
     "jest-snapshot": "^26.6.2"

--- a/src/Process.js
+++ b/src/Process.js
@@ -42,7 +42,7 @@ export const createProcess = (workspace: ProjectWorkspace, args: Array<string>):
 
   if (workspace.debug) {
     // eslint-disable-next-line no-console
-    console.log(`spawning process with command=${runtimeExecutable.join(' ')}`);
+    console.log(`spawning process with command=${runtimeExecutable.join(' ')}`, 'options:', spawnOptions);
   }
 
   return spawn(runtimeExecutable.join(' '), [], spawnOptions);

--- a/src/__tests__/parsers/babel_parser.test.ts
+++ b/src/__tests__/parsers/babel_parser.test.ts
@@ -9,7 +9,7 @@
 
 import * as path from 'path';
 import {NamedBlock, ParseResult} from '../..';
-import {UNRESOLVED_FUNCTION_NAME, UNSUPPORTED_TEST_NAME, parse} from '../../parsers/babel_parser';
+import {parse} from '../../parsers/babel_parser';
 import {parseOptions} from '../../parsers/helper';
 
 const fixtures = path.resolve('fixtures');

--- a/src/__tests__/parsers/babel_parser.test.ts
+++ b/src/__tests__/parsers/babel_parser.test.ts
@@ -345,7 +345,7 @@ describe('parsers', () => {
       startCol: number,
       endLine: number,
       endCol: number,
-      hasDynamicName = false,
+      nameType = 'Literal',
       lastProperty: string = null
     ) => {
       expect(nBlock.name).toEqual(name);
@@ -353,7 +353,7 @@ describe('parsers', () => {
       expect(nBlock.nameRange.start.column).toEqual(startCol);
       expect(nBlock.nameRange.end.line).toEqual(endLine);
       expect(nBlock.nameRange.end.column).toEqual(endCol);
-      expect(nBlock.hasDynamicName).toEqual(hasDynamicName);
+      expect(nBlock.nameType).toEqual(nameType);
       if (lastProperty !== null) {
         expect(nBlock.lastProperty).toEqual(lastProperty);
       }
@@ -370,9 +370,9 @@ describe('parsers', () => {
       it('name range for template literals', () => {
         const parseResult = parseFunction(`${fixtures}/template-literal.example`);
         let itBlock = parseResult.itBlocks[0];
-        assertNameInfo(itBlock, 'test has no expression either', 2, 7, 2, 35, true);
+        assertNameInfo(itBlock, 'test has no expression either', 2, 7, 2, 35, 'TemplateLiteral');
         itBlock = parseResult.itBlocks[1];
-        assertNameInfo(itBlock, '${expression} up front', 8, 12, 8, 33, true);
+        assertNameInfo(itBlock, '${expression} up front', 8, 12, 8, 33, 'TemplateLiteral');
         itBlock = parseResult.itBlocks[5];
         assertNameInfo(
           itBlock,
@@ -382,7 +382,7 @@ describe('parsers', () => {
           7,
           23,
           18,
-          true
+          'TemplateLiteral'
         );
       });
     });
@@ -436,7 +436,7 @@ describe('parsers', () => {
 
         const itBlock = parseResult.itBlocks[0];
         assertBlock2(itBlock, 2, 7, 4, 9, 'each test %p');
-        assertNameInfo(itBlock, 'each test %p', 2, 33, 2, 44, false, 'each');
+        assertNameInfo(itBlock, 'each test %p', 2, 33, 2, 44, 'Literal', 'each');
       });
       it('should be able to detect it.skip.each', () => {
         const data = `
@@ -450,7 +450,7 @@ describe('parsers', () => {
 
         const itBlock = parseResult.itBlocks[0];
         assertBlock2(itBlock, 2, 7, 4, 9, 'each test %p');
-        assertNameInfo(itBlock, 'each test %p', 2, 38, 2, 49, false, 'each');
+        assertNameInfo(itBlock, 'each test %p', 2, 38, 2, 49, 'Literal', 'each');
       });
 
       it('For the simplest it.each cases', () => {
@@ -816,7 +816,7 @@ describe('parsers', () => {
         ${'it.each([[1],[2]])("abc", ()=> {});'}                 | ${'each'}    | ${true}
         ${'it.concurrent.skip.each([[1],[2]])("abc", ()=> {});'} | ${'each'}    | ${true}
         ${'describe.each([[1],[2]])("abc", ()=> {});'}           | ${'each'}    | ${false}
-        ${'it.skip("abc", ()=> {});'}                            | ${'skip'}    | ${true}
+        ${'it.skip(5, ()=> {});'}                                | ${'skip'}    | ${true}
         ${'it.skip(`a ${dynamic} name`, ()=> {});'}              | ${'skip'}    | ${true}
       `('check lastProperty in $data', ({data, lastProperty, isItBlock}) => {
         const parseResult = parseFunction('whatever', data);
@@ -863,7 +863,7 @@ describe('parsers', () => {
 
         const itBlock = parseResult.itBlocks[0];
         assertBlock2(itBlock, 5, 11, 7, 13, 'String(item)');
-        assertNameInfo(itBlock, 'String(item)', 5, 17, 5, 26, true);
+        assertNameInfo(itBlock, 'String(item)', 5, 17, 5, 26, 'CallExpression');
       });
       it('return statement without arguments should not crash', () => {
         const data = `
@@ -887,7 +887,7 @@ describe('parsers', () => {
         expect(parseResult.itBlocks.length).toEqual(1);
 
         const dBlock = parseResult.describeBlocks[0];
-        assertNameInfo(dBlock, 'functionDotName.name', 2, 19, 2, 36, true);
+        assertNameInfo(dBlock, 'functionDotName.name', 2, 19, 2, 36, 'MemberExpression');
 
         const itBlock = parseResult.itBlocks[0];
         assertBlock2(itBlock, 3, 11, 3, 39, 'should parse');

--- a/src/__tests__/parsers/parser_nodes.test.js
+++ b/src/__tests__/parsers/parser_nodes.test.js
@@ -39,6 +39,15 @@ describe('ParsedNode', () => {
     filtered = c1_1.filter((n) => n.type === 'it', true);
     expect(filtered.length).toEqual(1);
   });
+  it('can attach lastProperty for NamedBlock', () => {
+    const itBlock = new ItBlock('abc.js', 'a test', 'each');
+    expect(itBlock.lastProperty).toEqual('each');
+    expect(itBlock.name).toEqual('a test');
+
+    const descBlock = new DescribeBlock('abc.js', 'a describe', 'only');
+    expect(descBlock.lastProperty).toEqual('only');
+    expect(descBlock.name).toEqual('a describe');
+  });
 });
 
 describe('ParseResult', () => {

--- a/src/__tests__/parsers/parser_nodes.test.js
+++ b/src/__tests__/parsers/parser_nodes.test.js
@@ -40,11 +40,13 @@ describe('ParsedNode', () => {
     expect(filtered.length).toEqual(1);
   });
   it('can attach lastProperty for NamedBlock', () => {
-    const itBlock = new ItBlock('abc.js', 'a test', 'each');
+    const itBlock = new ItBlock('abc.js', 'a test');
+    itBlock.lastProperty = 'each';
     expect(itBlock.lastProperty).toEqual('each');
     expect(itBlock.name).toEqual('a test');
 
-    const descBlock = new DescribeBlock('abc.js', 'a describe', 'only');
+    const descBlock = new DescribeBlock('abc.js', 'a describe');
+    descBlock.lastProperty = 'only';
     expect(descBlock.lastProperty).toEqual('only');
     expect(descBlock.name).toEqual('a describe');
   });

--- a/src/__tests__/process.test.js
+++ b/src/__tests__/process.test.js
@@ -13,8 +13,13 @@ import {createProcess} from '../Process';
 jest.mock('child_process');
 
 describe('createProcess', () => {
+  let mockConsoleLog;
+  beforeEach(() => {
+    mockConsoleLog = jest.spyOn(console, 'log');
+  });
   afterEach(() => {
     jest.resetAllMocks();
+    mockConsoleLog.mockRestore();
   });
 
   it('spawns the process', () => {
@@ -117,5 +122,13 @@ describe('createProcess', () => {
     expect(spawn.mock.calls[1][2].detached).toBe(false);
 
     global.process = savedProcess;
+  });
+  it('in debug mode, it will log spawn message', () => {
+    const workspace: any = {rootPath: 'abc', debug: true};
+    const args = [];
+
+    createProcess(workspace, args);
+    expect(spawn).toBeCalled();
+    expect(mockConsoleLog).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/process.test.js
+++ b/src/__tests__/process.test.js
@@ -15,7 +15,7 @@ jest.mock('child_process');
 describe('createProcess', () => {
   let mockConsoleLog;
   beforeEach(() => {
-    mockConsoleLog = jest.spyOn(console, 'log');
+    mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
   });
   afterEach(() => {
     jest.resetAllMocks();

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -42,7 +42,7 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
   const updateNameInfo = (nBlock: NamedBlock, bNode: BabelNode, lastProperty?: string) => {
     const arg = bNode.expression.arguments[0];
     let name = arg.value;
-    const hasDynamicName = !arg.value;
+    const hasDynamicName = arg.type !== 'Literal';
 
     if (!name) {
       switch (arg.type) {

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -42,7 +42,7 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
       return rootForType;
     }, node);
 
-  const updateNameInfo = (nBlock: NamedBlock, bNode: BabelNode) => {
+  const updateNameInfo = (nBlock: NamedBlock, bNode: BabelNode, lastProperty?: string) => {
     const arg = bNode.expression.arguments[0];
     let name = arg.value;
 
@@ -64,6 +64,7 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
     }
 
     nBlock.name = name;
+    nBlock.lastProperty = lastProperty;
     nBlock.nameRange = new ParsedRange(
       arg.loc.start.line,
       arg.loc.start.column + 2,
@@ -72,14 +73,14 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
     );
   };
 
-  const updateNode = (node: ParsedNode, babylonNode: BabelNode) => {
+  const updateNode = (node: ParsedNode, babylonNode: BabelNode, lastProperty?: string) => {
     node.start = babylonNode.loc.start;
     node.end = babylonNode.loc.end;
     node.start.column += 1;
 
     parseResult.addNode(node);
     if (node instanceof NamedBlock) {
-      updateNameInfo(node, babylonNode);
+      updateNameInfo(node, babylonNode, lastProperty);
     }
   };
 
@@ -89,11 +90,12 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
   const isFunctionDeclaration = (nodeType: string) =>
     nodeType === 'ArrowFunctionExpression' || nodeType === 'FunctionExpression';
 
-  // Pull out the name of a CallExpression (describe/it)
+  // Pull out the name of a CallExpression (describe/it) and the last property (each, skip etc)
   const getNameForNode = (node) => {
     if (isFunctionCall(node) && node.expression.callee) {
       // Get root callee in case it's a chain of higher-order functions (e.g. .each(table)(name, fn))
       const rootCallee = deepGet(node.expression, 'callee');
+      const property = rootCallee.property?.name || deepGet(rootCallee, 'tag').property?.name;
       const name =
         rootCallee.name ||
         // handle cases where it's a member expression (e.g .only or .concurrent.only)
@@ -101,20 +103,18 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
         // handle cases where it's part of a tag (e.g. .each`table`)
         deepGet(rootCallee, 'tag', 'object').name;
 
-      return name;
+      return [name, property];
     }
-    return undefined;
+    return [];
   };
 
   // When given a node in the AST, does this represent
   // the start of an it/test block?
-  const isAnIt = (node) => {
-    const name = getNameForNode(node);
+  const isAnIt = (name?: string) => {
     return name === 'it' || name === 'fit' || name === 'test';
   };
 
-  const isAnDescribe = (node) => {
-    const name = getNameForNode(node);
+  const isAnDescribe = (name?: string) => {
     return name === 'describe';
   };
 
@@ -136,9 +136,14 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
     return name === 'expect';
   };
 
-  const addNode = (type: ParsedNodeType, parent: ParsedNode, babylonNode: BabelNode): ParsedNode => {
+  const addNode = (
+    type: ParsedNodeType,
+    parent: ParsedNode,
+    babylonNode: BabelNode,
+    lastProperty?: string
+  ): ParsedNode => {
     const child = parent.addChild(type);
-    updateNode(child, babylonNode);
+    updateNode(child, babylonNode, lastProperty);
 
     if (child instanceof NamedBlock && child.name == null) {
       // eslint-disable-next-line no-console
@@ -161,10 +166,11 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
       // Pull out the node
       // const element = babylonParent.body[node];
 
-      if (isAnDescribe(element)) {
-        child = addNode('describe', parent, element);
-      } else if (isAnIt(element)) {
-        child = addNode('it', parent, element);
+      const [name, lastProperty] = getNameForNode(element);
+      if (isAnDescribe(name)) {
+        child = addNode('describe', parent, element, lastProperty);
+      } else if (isAnIt(name)) {
+        child = addNode('it', parent, element, lastProperty);
       } else if (isAnExpect(element)) {
         child = addNode('expect', parent, element);
       } else if (element && element.type === 'VariableDeclaration') {

--- a/src/parsers/babel_parser.js
+++ b/src/parsers/babel_parser.js
@@ -42,7 +42,6 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
   const updateNameInfo = (nBlock: NamedBlock, bNode: BabelNode, lastProperty?: string) => {
     const arg = bNode.expression.arguments[0];
     let name = arg.value;
-    const hasDynamicName = arg.type !== 'Literal';
 
     if (!name) {
       switch (arg.type) {
@@ -56,7 +55,7 @@ export const parse = (file: string, data: ?string, options: ?parser.ParserOption
     }
 
     nBlock.name = name;
-    nBlock.hasDynamicName = hasDynamicName;
+    nBlock.nameType = arg.type;
     nBlock.lastProperty = lastProperty;
     nBlock.nameRange = new ParsedRange(
       arg.loc.start.line,

--- a/src/parsers/parser_nodes.js
+++ b/src/parsers/parser_nodes.js
@@ -109,23 +109,22 @@ export class NamedBlock extends ParsedNode {
   /** indicate if the name of the block is plain string or dynamically named, such as template-literal, other function */
   hasDynamicName: ?boolean;
 
-  constructor(type: ParsedNodeType, file: string, name?: string, lastProperty?: string) {
+  constructor(type: ParsedNodeType, file: string, name?: string) {
     super(type, file);
     if (name) {
       this.name = name;
     }
-    this.lastProperty = lastProperty;
   }
 }
 
 export class ItBlock extends NamedBlock {
-  constructor(file: string, name?: string, lastProperty?: string) {
-    super(ParsedNodeTypes.it, file, name, lastProperty);
+  constructor(file: string, name?: string) {
+    super(ParsedNodeTypes.it, file, name);
   }
 }
 export class DescribeBlock extends NamedBlock {
-  constructor(file: string, name?: string, lastProperty?: string) {
-    super(ParsedNodeTypes.describe, file, name, lastProperty);
+  constructor(file: string, name?: string) {
+    super(ParsedNodeTypes.describe, file, name);
   }
 }
 

--- a/src/parsers/parser_nodes.js
+++ b/src/parsers/parser_nodes.js
@@ -106,8 +106,12 @@ export class NamedBlock extends ParsedNode {
 
   lastProperty: ?string;
 
-  /** indicate if the name of the block is plain string or dynamically named, such as template-literal, other function */
-  hasDynamicName: ?boolean;
+  /**
+   * type of the name, it's the babel Node["type"], such as "Literal", "TemplateLiteral" etc
+   *
+   * TODO babel parser currently returns "Literal" for the it/describe name argument, which is not part of its "type" definition, therefore declare a string type for now until it is fixed in babel.
+   * */
+  nameType: ?string;
 
   constructor(type: ParsedNodeType, file: string, name?: string) {
     super(type, file);

--- a/src/parsers/parser_nodes.js
+++ b/src/parsers/parser_nodes.js
@@ -102,9 +102,12 @@ export class Expect extends ParsedNode {
 export class NamedBlock extends ParsedNode {
   name: string;
 
+  nameRange: ParsedRange;
+
   lastProperty: ?string;
 
-  nameRange: ParsedRange;
+  /** indicate if the name of the block is plain string or dynamically named, such as template-literal, other function */
+  hasDynamicName: ?boolean;
 
   constructor(type: ParsedNodeType, file: string, name?: string, lastProperty?: string) {
     super(type, file);

--- a/src/parsers/parser_nodes.js
+++ b/src/parsers/parser_nodes.js
@@ -102,24 +102,27 @@ export class Expect extends ParsedNode {
 export class NamedBlock extends ParsedNode {
   name: string;
 
+  lastProperty: ?string;
+
   nameRange: ParsedRange;
 
-  constructor(type: ParsedNodeType, file: string, name?: string) {
+  constructor(type: ParsedNodeType, file: string, name?: string, lastProperty?: string) {
     super(type, file);
     if (name) {
       this.name = name;
     }
+    this.lastProperty = lastProperty;
   }
 }
 
 export class ItBlock extends NamedBlock {
-  constructor(file: string, name?: string) {
-    super(ParsedNodeTypes.it, file, name);
+  constructor(file: string, name?: string, lastProperty?: string) {
+    super(ParsedNodeTypes.it, file, name, lastProperty);
   }
 }
 export class DescribeBlock extends NamedBlock {
-  constructor(file: string, name?: string) {
-    super(ParsedNodeTypes.describe, file, name);
+  constructor(file: string, name?: string, lastProperty?: string) {
+    super(ParsedNodeTypes.describe, file, name, lastProperty);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -503,7 +503,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.7.0", "@babel/parser@^7.8.3", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
+"@babel/parser@^7.1.0", "@babel/parser@^7.7.0", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
   integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
@@ -517,6 +517,11 @@
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.3.tgz#9b530eecb071fd0c93519df25c5ff9f14759f298"
   integrity sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ==
+
+"@babel/parser@^7.14.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.4.tgz#a5c560d6db6cd8e6ed342368dea8039232cbab18"
+  integrity sha512-ArliyUsWDUqEGfWcmzpGUzNfLxTdTp6WU4IuP6QFSp9gGfWS6boxFCkJSJ/L4+RG8z/FnIU3WxCk6hPL9SSWeA==
 
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
@@ -1160,6 +1165,14 @@
   version "7.14.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.2.tgz#4208ae003107ef8a057ea8333e56eb64d2f6a2c3"
   integrity sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.0"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.14.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.4.tgz#bfd6980108168593b38b3eb48a24aa026b919bc0"
+  integrity sha512-lCj4aIs0xUefJFQnwwQv2Bxg7Omd6bgquZ6LGC+gGMh6/s5qDVfjuCMlDmYQ15SLsWHd9n+X3E75lKIhl5Lkiw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"


### PR DESCRIPTION
This PR updated parser to expose more and accurate attributes for the NamedBlock to help consumers matching the jest test results better:

1. preserve the "name" of the NamedBlock. It was using markers before, which might not be helpful when we want to show users what block it is. (this might be a breaking change if people are using the markers for something...)
2. added a new optional attribute `lastProperty` to help identify if the block is a `each` block for example. The "last property" is the "each" in `describe.skip.each()` or "only" in `it.only()`.
3. added a new optional attribute `nameType` to help identify the block's "name" type, such as 'Literal', 'TemplateLiteral', 'CallExpression'. This not only helps identify if the name is a static literal string that should match the test results' name, it also helps people that used to rely on the type-marker used in the "name" field before. 
4. upgraded dependency `@babel/parser` to the latest 7.x

