### PR TITLE
Disable jsx plugin for .ts files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Bug-fixes within the same version aren't needed
 ## Master
 * convert `parser-test.js` to a true jest test: `babel-parser.test.ts` and convert to typescript. - @connectdotz
 * upgrade prettier and @babel/preset-typescript, fix lint errors. - @connectdotz
+* remove JSX plugin for `.ts` files
 -->
 
 ### 28.2.0

--- a/fixtures/describe_eaches.example
+++ b/fixtures/describe_eaches.example
@@ -11,10 +11,6 @@ describe.each(['a', 'b', 'c'])('works with flow functions', () => {
   function foo(x: string): string { return x; }
 });
 
-describe.each(['a', 'b', 'c'])('works with JSX', () => {
-  const foo = () => <div></div>;
-});
-
 describe.only.each(['a', 'b', 'c'])('works with describe.only', () => {
 
 });

--- a/fixtures/global_it_eaches.example
+++ b/fixtures/global_it_eaches.example
@@ -11,10 +11,6 @@ it.each(['a', 'b', 'c'])('works with flow functions', () => {
   function foo(x: string): string { return x; }
 });
 
-it.each(['a', 'b', 'c'])('works with JSX', () => {
-  const foo = () => <div></div>;
-});
-
 it.only.each(['a', 'b', 'c'])('works with it.only', () => {
 
 });

--- a/fixtures/global_its.example
+++ b/fixtures/global_its.example
@@ -11,10 +11,6 @@ it('works with flow functions', () => {
   function foo(x: string): string { return x; }
 });
 
-it('works with JSX', ()=> {
-  const foo = () => <div></div>;
-});
-
 it.only('works with it.only', () => {
 
 });

--- a/fixtures/global_its.example
+++ b/fixtures/global_its.example
@@ -13,7 +13,7 @@ it('works with flow functions', () => {
 
 it('works with JSX', ()=> {
   const foo = () => <div></div>;
-})
+});
 
 it.only('works with it.only', () => {
 

--- a/src/__tests__/parsers/babel_parser.test.ts
+++ b/src/__tests__/parsers/babel_parser.test.ts
@@ -91,29 +91,24 @@ describe('parsers', () => {
               end: {column: 3, line: 12},
             },
             {
-              name: 'works with JSX',
+              name: 'works with it.only',
               start: {column: 1, line: 14},
               end: {column: 3, line: 16},
             },
             {
-              name: 'works with it.only',
+              name: 'works with fit',
               start: {column: 1, line: 18},
               end: {column: 3, line: 20},
             },
             {
-              name: 'works with fit',
+              name: 'works with test',
               start: {column: 1, line: 22},
               end: {column: 3, line: 24},
             },
             {
-              name: 'works with test',
+              name: 'works with test.only',
               start: {column: 1, line: 26},
               end: {column: 3, line: 28},
-            },
-            {
-              name: 'works with test.only',
-              start: {column: 1, line: 30},
-              end: {column: 3, line: 32},
             },
           ],
         });
@@ -153,6 +148,28 @@ describe('parsers', () => {
               name: '6',
               start: {column: 3, line: 24},
               end: {column: 5, line: 25},
+            },
+          ],
+        });
+      });
+
+      it('For it with JSX', () => {
+        if (fileName.match(/ts$/)) {
+          return;
+        }
+        const data = `
+          it('works with JSX', ()=> {
+            const foo = () => <div></div>;
+          });
+        `;
+        const parseResult = parseFunction(fileName, data);
+
+        expect(parseResult).toMatchObject({
+          itBlocks: [
+            {
+              name: 'works with JSX',
+              start: {column: 11, line: 2},
+              end: {column: 13, line: 4},
             },
           ],
         });
@@ -460,63 +477,80 @@ describe('parsers', () => {
               end: {line: 12, column: 3},
             },
             {
-              name: 'works with JSX',
+              name: 'works with it.only',
               start: {line: 14, column: 1},
               end: {line: 16, column: 3},
             },
             {
-              name: 'works with it.only',
+              name: 'works with it.concurrent',
               start: {line: 18, column: 1},
               end: {line: 20, column: 3},
             },
             {
-              name: 'works with it.concurrent',
+              name: 'works with it.concurrent.only',
               start: {line: 22, column: 1},
               end: {line: 24, column: 3},
             },
             {
-              name: 'works with it.concurrent.only',
+              name: 'works with it.concurrent.skip',
               start: {line: 26, column: 1},
               end: {line: 28, column: 3},
             },
             {
-              name: 'works with it.concurrent.skip',
+              name: 'works with fit',
               start: {line: 30, column: 1},
               end: {line: 32, column: 3},
             },
             {
-              name: 'works with fit',
+              name: 'works with test',
               start: {line: 34, column: 1},
               end: {line: 36, column: 3},
             },
             {
-              name: 'works with test',
+              name: 'works with test.only',
               start: {line: 38, column: 1},
               end: {line: 40, column: 3},
             },
             {
-              name: 'works with test.only',
+              name: 'works with test.concurrent',
               start: {line: 42, column: 1},
               end: {line: 44, column: 3},
             },
             {
-              name: 'works with test.concurrent',
+              name: 'works with test.concurrent.only',
               start: {line: 46, column: 1},
               end: {line: 48, column: 3},
             },
             {
-              name: 'works with test.concurrent.only',
+              name: 'works with test.concurrent.skip',
               start: {line: 50, column: 1},
               end: {line: 52, column: 3},
-            },
-            {
-              name: 'works with test.concurrent.skip',
-              start: {line: 54, column: 1},
-              end: {line: 56, column: 3},
             },
           ],
           describeBlocks: [
             // No describes
+          ],
+        });
+      });
+
+      it('For it.each with JSX', () => {
+        if (fileName.match(/ts$/)) {
+          return;
+        }
+        const data = `
+          it.each(['a', 'b', 'c'])('works with JSX', () => {
+            const foo = () => <div></div>;
+          });
+        `;
+        const parseResult = parseFunction(fileName, data);
+
+        expect(parseResult).toMatchObject({
+          itBlocks: [
+            {
+              name: 'works with JSX',
+              start: {column: 11, line: 2},
+              end: {column: 13, line: 4},
+            },
           ],
         });
       });
@@ -545,29 +579,71 @@ describe('parsers', () => {
               end: {line: 12, column: 3},
             },
             {
-              name: 'works with JSX',
+              name: 'works with describe.only',
               start: {line: 14, column: 1},
               end: {line: 16, column: 3},
             },
             {
-              name: 'works with describe.only',
+              name: 'works with describe.concurrent',
               start: {line: 18, column: 1},
               end: {line: 20, column: 3},
             },
             {
-              name: 'works with describe.concurrent',
+              name: 'works with describe.concurrent.only',
               start: {line: 22, column: 1},
               end: {line: 24, column: 3},
             },
             {
-              name: 'works with describe.concurrent.only',
+              name: 'works with describe.concurrent.skip',
               start: {line: 26, column: 1},
               end: {line: 28, column: 3},
             },
+          ],
+        });
+      });
+
+      it('For describe.each with JSX', () => {
+        if (fileName.match(/ts$/)) {
+          return;
+        }
+        const data = `
+          describe.each(['a', 'b', 'c'])('works with JSX', () => {
+            const foo = () => <div></div>;
+          });
+        `;
+        const parseResult = parseFunction(fileName, data);
+
+        expect(parseResult).toMatchObject({
+          itBlocks: [
+            // No tests
+          ],
+          describeBlocks: [
             {
-              name: 'works with describe.concurrent.skip',
-              start: {line: 30, column: 1},
-              end: {line: 32, column: 3},
+              name: 'works with JSX',
+              start: {column: 11, line: 2},
+              end: {column: 13, line: 4},
+            },
+          ],
+        });
+      });
+
+      it('For it.each with JSX', () => {
+        if (fileName.match(/ts$/)) {
+          return;
+        }
+        const data = `
+          it.each(['a', 'b', 'c'])('works with JSX', () => {
+            const foo = () => <div></div>;
+          });
+        `;
+        const parseResult = parseFunction(fileName, data);
+
+        expect(parseResult).toMatchObject({
+          itBlocks: [
+            {
+              name: 'works with JSX',
+              start: {column: 11, line: 2},
+              end: {column: 13, line: 4},
             },
           ],
         });
@@ -707,6 +783,7 @@ describe('parsers', () => {
           ],
         });
       });
+
       it('should be able to detect test.each with a bit different layout', () => {
         const data = `
       test.each(['a','b', 'c'])(

--- a/src/__tests__/parsers/babel_parser.test.ts
+++ b/src/__tests__/parsers/babel_parser.test.ts
@@ -949,7 +949,6 @@ describe('parsers', () => {
         assertNameInfo(itBlock, name, 7, 12, 7, 48);
       });
       it('https://github.com/jest-community/jest-editor-support/issues/68', () => {
-        // if (!fileName.match(/ts$/)) {
         if (!fileName.match(/ts$/)) {
           return;
         }

--- a/src/__tests__/parsers/babel_parser.test.ts
+++ b/src/__tests__/parsers/babel_parser.test.ts
@@ -948,6 +948,21 @@ describe('parsers', () => {
         assertBlock2(itBlock, 2, 9, 9, 11, name);
         assertNameInfo(itBlock, name, 7, 12, 7, 48);
       });
+      it('https://github.com/jest-community/jest-editor-support/issues/68', () => {
+        // if (!fileName.match(/ts$/)) {
+        if (!fileName.match(/ts$/)) {
+          return;
+        }
+        const data = `
+          it('should parse', () => {
+            const value = <number> num;
+          });
+        `;
+        const parseResult = parseFunction(fileName, data);
+        expect(parseResult.itBlocks.length).toEqual(1);
+        const itBlock = parseResult.itBlocks[0];
+        assertBlock2(itBlock, 2, 11, 4, 13, 'should parse');
+      });
     });
   });
 });

--- a/src/__tests__/parsers/babel_parser.test.ts
+++ b/src/__tests__/parsers/babel_parser.test.ts
@@ -70,85 +70,92 @@ describe('parsers', () => {
     // actual tests
     describe('File Parsing for it blocks', () => {
       it('For the simplest it cases', () => {
-        const data = parseFunction(`${fixtures}/global_its.example`);
+        const parseResult = parseFunction(`${fixtures}/global_its.example`);
 
-        expect(data.itBlocks.length).toEqual(8);
+        expect(parseResult).toMatchObject({
+          itBlocks: [
+            {
+              name: 'works with old functions',
+              start: {column: 1, line: 2},
+              end: {column: 3, line: 4},
+            },
 
-        const firstIt = data.itBlocks[0];
-        expect(firstIt.name).toEqual('works with old functions');
-        expect(firstIt.start).toEqual({column: 1, line: 2});
-        expect(firstIt.end).toEqual({column: 3, line: 4});
-
-        const secondIt = data.itBlocks[1];
-        expect(secondIt.name).toEqual('works with new functions');
-        expect(secondIt.start).toEqual({column: 1, line: 6});
-        expect(secondIt.end).toEqual({column: 3, line: 8});
-
-        const thirdIt = data.itBlocks[2];
-        expect(thirdIt.name).toEqual('works with flow functions');
-        expect(thirdIt.start).toEqual({column: 1, line: 10});
-        expect(thirdIt.end).toEqual({column: 3, line: 12});
-
-        const fourthIt = data.itBlocks[2];
-        expect(fourthIt.name).toEqual('works with flow functions');
-        expect(fourthIt.start).toEqual({column: 1, line: 10});
-        expect(fourthIt.end).toEqual({column: 3, line: 12});
-
-        const fifthIt = data.itBlocks[4];
-        expect(fifthIt.name).toEqual('works with it.only');
-        expect(fifthIt.start).toEqual({column: 1, line: 18});
-        expect(fifthIt.end).toEqual({column: 3, line: 20});
-
-        const sixthIt = data.itBlocks[5];
-        expect(sixthIt.name).toEqual('works with fit');
-        expect(sixthIt.start).toEqual({column: 1, line: 22});
-        expect(sixthIt.end).toEqual({column: 3, line: 24});
-
-        const seventhIt = data.itBlocks[6];
-        expect(seventhIt.name).toEqual('works with test');
-        expect(seventhIt.start).toEqual({column: 1, line: 26});
-        expect(seventhIt.end).toEqual({column: 3, line: 28});
-
-        const eigthIt = data.itBlocks[7];
-        expect(eigthIt.name).toEqual('works with test.only');
-        expect(eigthIt.start).toEqual({column: 1, line: 30});
-        expect(eigthIt.end).toEqual({column: 3, line: 32});
+            {
+              name: 'works with new functions',
+              start: {column: 1, line: 6},
+              end: {column: 3, line: 8},
+            },
+            {
+              name: 'works with flow functions',
+              start: {column: 1, line: 10},
+              end: {column: 3, line: 12},
+            },
+            {
+              name: 'works with JSX',
+              start: {column: 1, line: 14},
+              end: {column: 3, line: 16},
+            },
+            {
+              name: 'works with it.only',
+              start: {column: 1, line: 18},
+              end: {column: 3, line: 20},
+            },
+            {
+              name: 'works with fit',
+              start: {column: 1, line: 22},
+              end: {column: 3, line: 24},
+            },
+            {
+              name: 'works with test',
+              start: {column: 1, line: 26},
+              end: {column: 3, line: 28},
+            },
+            {
+              name: 'works with test.only',
+              start: {column: 1, line: 30},
+              end: {column: 3, line: 32},
+            },
+          ],
+        });
       });
 
       it('For its inside describes', () => {
-        const data = parse(`${fixtures}/nested_its.example`);
+        const parseResult = parse(`${fixtures}/nested_its.example`);
 
-        expect(data.itBlocks.length).toEqual(6);
-
-        const firstIt = data.itBlocks[0];
-        expect(firstIt.name).toEqual('1');
-        expect(firstIt.start).toEqual({column: 3, line: 2});
-        expect(firstIt.end).toEqual({column: 5, line: 3});
-
-        const secondIt = data.itBlocks[1];
-        expect(secondIt.name).toEqual('2');
-        expect(secondIt.start).toEqual({column: 3, line: 4});
-        expect(secondIt.end).toEqual({column: 5, line: 5});
-
-        const thirdIt = data.itBlocks[2];
-        expect(thirdIt.name).toEqual('3');
-        expect(thirdIt.start).toEqual({column: 3, line: 9});
-        expect(thirdIt.end).toEqual({column: 5, line: 10});
-
-        const fourthIt = data.itBlocks[3];
-        expect(fourthIt.name).toEqual('4');
-        expect(fourthIt.start).toEqual({column: 3, line: 14});
-        expect(fourthIt.end).toEqual({column: 5, line: 15});
-
-        const fifthIt = data.itBlocks[4];
-        expect(fifthIt.name).toEqual('5');
-        expect(fifthIt.start).toEqual({column: 3, line: 19});
-        expect(fifthIt.end).toEqual({column: 5, line: 20});
-
-        const sixthIt = data.itBlocks[5];
-        expect(sixthIt.name).toEqual('6');
-        expect(sixthIt.start).toEqual({column: 3, line: 24});
-        expect(sixthIt.end).toEqual({column: 5, line: 25});
+        expect(parseResult).toMatchObject({
+          itBlocks: [
+            {
+              name: '1',
+              start: {column: 3, line: 2},
+              end: {column: 5, line: 3},
+            },
+            {
+              name: '2',
+              start: {column: 3, line: 4},
+              end: {column: 5, line: 5},
+            },
+            {
+              name: '3',
+              start: {column: 3, line: 9},
+              end: {column: 5, line: 10},
+            },
+            {
+              name: '4',
+              start: {column: 3, line: 14},
+              end: {column: 5, line: 15},
+            },
+            {
+              name: '5',
+              start: {column: 3, line: 19},
+              end: {column: 5, line: 20},
+            },
+            {
+              name: '6',
+              start: {column: 3, line: 24},
+              end: {column: 5, line: 25},
+            },
+          ],
+        });
       });
 
       // These tests act more like linters that we don't raise on
@@ -703,7 +710,7 @@ describe('parsers', () => {
       it('should be able to detect test.each with a bit different layout', () => {
         const data = `
       test.each(['a','b', 'c'])(
-        'each test %p', 
+        'each test %p',
         (v) => {
         expect(v).not.toBeUndefined();
       });

--- a/src/__tests__/parsers/helper.test.js
+++ b/src/__tests__/parsers/helper.test.js
@@ -9,45 +9,31 @@
 
 import * as helper from '../../parsers/helper';
 
-jest.mock('../../parsers/babel_parser', () => {
-  return {parse: jest.fn()};
-});
-
-describe('getFileType', () => {
-  it('returns js for .js or .jsx or .mjs file', () => {
-    const files = ['abc.js', 'abc.jsx', 'abc.mjs'];
+describe('parseOptions', () => {
+  it('returns jsOptions for .js or .jsx or .mjs file', () => {
+    const files = ['abc.js', 'abc.jsx', 'abc.mjs', 'abc.JS', 'abc.JSX', 'abc.MJS'];
     files.forEach((file) => {
-      expect(helper.getFileType(file)).toEqual('js');
-      jest.clearAllMocks();
+      expect(helper.parseOptions(file)).toEqual({plugins: helper.jsPlugins});
     });
   });
-  it('returns ts for .ts', async () => {
-    expect(helper.getFileType('abc.ts')).toEqual('ts');
+  it('returns tsOptions for .ts', () => {
+    const files = ['abc.ts', 'abc.TS'];
+    files.forEach((file) => {
+      expect(helper.parseOptions(file)).toEqual({plugins: helper.tsPlugins});
+    });
   });
-  it('returns tsx for .tsx', async () => {
-    expect(helper.getFileType('abc.tsx')).toEqual('tsx');
-  });
-});
-
-describe('parseOption', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-  it('js file should contain "flow" and "jsx" plugins', () => {
-    expect(helper.parseOptions('abc.js')).toEqual({plugins: [...helper.plugins, 'flow', 'jsx']});
-  });
-  it('ts file should contain "typescript" plugin', () => {
-    expect(helper.parseOptions('abc.ts')).toEqual({plugins: [...helper.plugins, 'typescript']});
-  });
-  it('tsx file should contain "typescript" and "jsx" plugins', () => {
-    expect(helper.parseOptions('abc.tsx')).toEqual({plugins: [...helper.plugins, 'typescript', 'jsx']});
+  it('returns tsxOptions for .tsx', () => {
+    const files = ['abc.tsx', 'abc.TSX'];
+    files.forEach((file) => {
+      expect(helper.parseOptions(file)).toEqual({plugins: helper.tsxPlugins});
+    });
   });
   describe('for unrecognized file type', () => {
     it('in strict mode, throw error', () => {
       expect(() => helper.parseOptions('abc.json', true)).toThrow();
     });
     it('in non-strict mode, use js options', () => {
-      expect(helper.parseOptions('abc.json', false)).toEqual({plugins: [...helper.plugins, 'flow', 'jsx']});
+      expect(helper.parseOptions('abc.json', false)).toEqual({plugins: helper.jsPlugins});
     });
   });
 });

--- a/src/__tests__/parsers/helper.test.js
+++ b/src/__tests__/parsers/helper.test.js
@@ -13,31 +13,41 @@ jest.mock('../../parsers/babel_parser', () => {
   return {parse: jest.fn()};
 });
 
-describe('supportedFileType', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-  it('for .js or .jsx or .mjs file', () => {
+describe('getFileType', () => {
+  it('returns js for .js or .jsx or .mjs file', () => {
     const files = ['abc.js', 'abc.jsx', 'abc.mjs'];
     files.forEach((file) => {
-      expect(helper.supportedFileType(file)).toEqual('js');
+      expect(helper.getFileType(file)).toEqual('js');
       jest.clearAllMocks();
     });
   });
-  describe('parseOption', () => {
-    it('js file should contain "flow" plugin', () => {
-      expect(helper.parseOptions('abc.js')).toEqual({plugins: [...helper.plugins, 'flow']});
+  it('returns ts for .ts', async () => {
+    expect(helper.getFileType('abc.ts')).toEqual('ts');
+  });
+  it('returns tsx for .tsx', async () => {
+    expect(helper.getFileType('abc.tsx')).toEqual('tsx');
+  });
+});
+
+describe('parseOption', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('js file should contain "flow" and "jsx" plugins', () => {
+    expect(helper.parseOptions('abc.js')).toEqual({plugins: [...helper.plugins, 'flow', 'jsx']});
+  });
+  it('ts file should contain "typescript" plugin', () => {
+    expect(helper.parseOptions('abc.ts')).toEqual({plugins: [...helper.plugins, 'typescript']});
+  });
+  it('tsx file should contain "typescript" and "jsx" plugins', () => {
+    expect(helper.parseOptions('abc.tsx')).toEqual({plugins: [...helper.plugins, 'typescript', 'jsx']});
+  });
+  describe('for unrecognized file type', () => {
+    it('in strict mode, throw error', () => {
+      expect(() => helper.parseOptions('abc.json', true)).toThrow();
     });
-    it('ts file should contain "typescript" plugin', () => {
-      expect(helper.parseOptions('abc.ts')).toEqual({plugins: [...helper.plugins, 'typescript']});
-    });
-    describe('for unrecognized file type', () => {
-      it('in strict mode, throw error', () => {
-        expect(() => helper.parseOptions('abc.json', true)).toThrow();
-      });
-      it('in non-strict mode, use js options', () => {
-        expect(helper.parseOptions('abc.json', false)).toEqual({plugins: [...helper.plugins, 'flow']});
-      });
+    it('in non-strict mode, use js options', () => {
+      expect(helper.parseOptions('abc.json', false)).toEqual({plugins: [...helper.plugins, 'flow', 'jsx']});
     });
   });
 });

--- a/src/__tests__/parsers/parser_nodes.test.js
+++ b/src/__tests__/parsers/parser_nodes.test.js
@@ -39,6 +39,12 @@ describe('ParsedNode', () => {
     filtered = c1_1.filter((n) => n.type === 'it', true);
     expect(filtered.length).toEqual(1);
   });
+  it('throws an error when adding an unknown child', async () => {
+    const root = new ParsedNode('describe', 'a/b/c');
+    expect(() => {
+      root.addChild('unknown');
+    }).toThrow(TypeError);
+  });
 });
 
 describe('ParseResult', () => {
@@ -83,5 +89,12 @@ describe('ParseResult', () => {
     expect(result.describeBlocks.length).toEqual(2);
     expect(result.itBlocks.length).toEqual(0);
     expect(result.expects.length).toEqual(1);
+  });
+  it('throws an error on unknown node type', async () => {
+    const result = new ParseResult('a/b/c');
+    expect(() => {
+      const node = new ParsedNode('root', '');
+      result.addNode(node);
+    }).toThrow(TypeError);
   });
 });

--- a/src/parsers/helper.ts
+++ b/src/parsers/helper.ts
@@ -9,13 +9,17 @@
 import {ParserOptions, ParserPlugin} from '@babel/parser';
 
 /**
- * determine if the file is a typescript (ts), javascript (js) otherwise returns undefined.
+ * determine if the file is a javascript (js), typescript (ts), or typescript JSX (tsx),
+ * otherwise returns undefined.
  * @param filepath
- * @returns 'js'|'ts' or undefined
+ * @returns 'js'|'ts'|'tsx' or undefined
  */
-export const supportedFileType = (filePath: string): 'ts' | 'js' | undefined => {
-  if (filePath.match(/\.tsx?$/)) {
+export const getFileType = (filePath: string): 'js' | 'ts' | 'tsx' | undefined => {
+  if (filePath.match(/\.ts$/)) {
     return 'ts';
+  }
+  if (filePath.match(/\.tsx$/)) {
+    return 'tsx';
   }
   if (filePath.match(/\.m?jsx?$/)) {
     return 'js';
@@ -37,7 +41,6 @@ export const plugins: ParserPlugin[] = [
   'functionBind',
   'functionSent',
   'importMeta',
-  'jsx',
   'logicalAssignment',
   'nullishCoalescingOperator',
   'numericSeparator',
@@ -52,11 +55,14 @@ export const plugins: ParserPlugin[] = [
 ];
 
 export const parseOptions = (filePath: string, strictMode = false): ParserOptions | null => {
-  const fileType = supportedFileType(filePath);
+  const fileType = getFileType(filePath);
   if (fileType === 'ts') {
     return {plugins: [...plugins, 'typescript']};
   }
-  const jsOptions: ParserOptions = {plugins: [...plugins, 'flow']};
+  if (fileType === 'tsx') {
+    return {plugins: [...plugins, 'typescript', 'jsx']};
+  }
+  const jsOptions: ParserOptions = {plugins: [...plugins, 'flow', 'jsx']};
   if (fileType === 'js') {
     return jsOptions;
   }


### PR DESCRIPTION
The JSX plugin for Typescript is not compatible with bracket-style type assertions. This led to the introduction of the `as` keyword as an alternate:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-6.html#new-tsx-file-extension-and-as-operator

This restricts the plugin to only be used with `.tsx` files.

NOTE: There was a copy/paste error in the babel parser test that was skipping over the existing JSX test. Since other tests in the same file were using a comparison of the whole object that precludes such omissions, I changed the style of 2 of the tests to be consistent with this.