### PR TITLE
allow runner to use custom shell 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 build/
 coverage/
 *.tgz
+.eslintcache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
+* added `shell` argument to workspace config to allow users override spawn() child_process default shell - @connectdotz
+* remove `CI: true` env for spawned process, a better way to ensure non-watch mode run will be to explicitly add `--watchAll=false` jest option in the commadLine. - @connectdotz
 
 -->
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ import {EventEmitter} from 'events';
 import {ChildProcess} from 'child_process';
 import {Config as JestConfig} from '@jest/types';
 import { CoverageMapData } from 'istanbul-lib-coverage';
+import ProjectWorkspace, {ProjectWorkspaceConfig, createProjectWorkspace} from './src/project_workspace';
 
 export interface RunArgs {
   args: string[];
@@ -46,38 +47,8 @@ export interface JestSettings {
 
 export function getSettings(workspace: ProjectWorkspace, options?: Options): Promise<JestSettings>;
 
-export function createProjectWorkspace(config: ProjectWorkspaceConfig): ProjectWorkspace;
+export {createProjectWorkspace, ProjectWorkspaceConfig, ProjectWorkspace};
 
-export interface ProjectWorkspaceConfig {
-  jestCommandLine: string;
-  pathToConfig?: string;
-  rootPath: string;
-  localJestMajorVersion: number;
-  outputFileSuffix?: string;
-  collectCoverage?: boolean;
-  debug?: boolean;
-}
-
-export class ProjectWorkspace {
-  constructor(
-    rootPath: string,
-    jestCommandLine: string,
-    pathToConfig: string,
-    localJestMajorVersion: number,
-    outputFileSuffix?: string,
-    collectCoverage?: boolean,
-    debug?: boolean,
-    nodeEnv?: {[key: string]: string | undefined},
-  );
-  jestCommandLine: string;
-  pathToConfig: string;
-  rootPath: string;
-  localJestMajorVersion: number;
-  outputFileSuffix?: string;
-  collectCoverage?: boolean;
-  debug?: boolean;
-  nodeEnv?: {[key: string]: string | undefined};
-}
 
 export interface IParseResults {
   describeBlocks: Array<DescribeBlock>;

--- a/src/Process.js
+++ b/src/Process.js
@@ -26,14 +26,12 @@ export const createProcess = (workspace: ProjectWorkspace, args: Array<string>):
     runtimeExecutable.push(workspace.pathToConfig);
   }
 
-  // To use our own commands in create-react, we need to tell the command that
-  // we're in a CI environment, or it will always append --watch
-  const env = {...process.env, ...(workspace.nodeEnv ?? {}), CI: 'true'};
+  const env = {...process.env, ...(workspace.nodeEnv ?? {})};
 
   const spawnOptions = {
     cwd: workspace.rootPath,
     env,
-    shell: true,
+    shell: typeof workspace.shell === 'string' && workspace.shell ? workspace.shell : true,
     // for non-windows: run in detached mode so the process will be the group leader and any subsequent process spawned
     // within can be later killed as a group to prevent orphan processes.
     // see https://nodejs.org/api/child_process.html#child_process_options_detached

--- a/src/__tests__/process.test.js
+++ b/src/__tests__/process.test.js
@@ -66,8 +66,8 @@ describe('createProcess', () => {
     expect(spawn.mock.calls[0][0]).toEqual('npm test -- --option value --config non-standard.jest.js');
   });
 
-  it('defines the "CI" environment variable', () => {
-    const expected = Object.assign({}, process.env, {CI: 'true'});
+  it('does not defines the "CI" environment variable', () => {
+    const expected = process.env;
 
     const workspace: any = {jestCommandLine: ''};
     const args = [];
@@ -77,12 +77,27 @@ describe('createProcess', () => {
   });
   it('allow customize node environment variable', () => {
     const workspace: any = {
-      nodeEnv: {NODE_ENV: 'test', CI: 'false'},
+      nodeEnv: {NODE_ENV: 'test'},
     };
-    const expected = Object.assign({}, process.env, workspace.nodeEnv, {CI: 'true'});
+    const expected = Object.assign({}, process.env, workspace.nodeEnv);
     createProcess(workspace, []);
 
     expect(spawn.mock.calls[0][2].env).toEqual(expected);
+  });
+  it.each`
+    shell               | expected
+    ${undefined}        | ${true}
+    ${false}            | ${true}
+    ${''}               | ${true}
+    ${'powerShell.exe'} | ${'powerShell.exe'}
+    ${'/bin/bash'}      | ${'/bin/bash'}
+  `('allow customize shell: $shell', ({shell, expected}) => {
+    const workspace: any = {
+      shell,
+    };
+    createProcess(workspace, []);
+
+    expect(spawn.mock.calls[0][2].shell).toEqual(expected);
   });
 
   it('sets the current working directory of the child process', () => {

--- a/src/project_workspace.ts
+++ b/src/project_workspace.ts
@@ -15,6 +15,7 @@ export interface ProjectWorkspaceConfig {
   collectCoverage?: boolean;
   debug?: boolean;
   nodeEnv?: {[key: string]: string | undefined};
+  shell?: string;
 }
 
 /**
@@ -99,6 +100,12 @@ export default class ProjectWorkspace {
    */
   nodeEnv?: {[key: string]: string | undefined};
 
+  /**
+   * optional custom shell for node child_process spawn() call. Default is '/bin/sh' on Unix, and process.env.ComSpec on Windows.
+   * see https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options
+   */
+  shell?: string;
+
   constructor(
     rootPath: string,
     jestCommandLine: string,
@@ -107,7 +114,8 @@ export default class ProjectWorkspace {
     outputFileSuffix?: string,
     collectCoverage?: boolean,
     debug?: boolean,
-    nodeEnv?: {[key: string]: string | undefined}
+    nodeEnv?: {[key: string]: string | undefined},
+    shell?: string
   ) {
     this.rootPath = rootPath;
     this.jestCommandLine = jestCommandLine;
@@ -117,6 +125,7 @@ export default class ProjectWorkspace {
     this.collectCoverage = collectCoverage;
     this.debug = debug;
     this.nodeEnv = nodeEnv;
+    this.shell = shell;
   }
 }
 
@@ -135,6 +144,7 @@ export const createProjectWorkspace = (config: ProjectWorkspaceConfig): ProjectW
     config.outputFileSuffix,
     config.collectCoverage,
     config.debug,
-    config.nodeEnv
+    config.nodeEnv,
+    config.shell
   );
 };


### PR DESCRIPTION
## motivation

We used to launch jest process with the default shell defined by Node child_process, however, there are issues like jest-community/vscode-jest#708 that would have worked in a different shell (powershell). There are also a few shell environment-related issues that could also benefit from specifying the same shell users actually use.

Also removed the `CI: true` flag in the process.env as a workaround in the past. Now, this is better served by adding an explicit jest argument `--watchAll=false` if needed. However since this could be a breaking change, we should cust a major release to be safe.

## summary
- added `shell` option in ProjectWorkspace
- remove `CI: true` flag in the runner env override. Projects can pass explicit `watchAll=false` to ensure the same effect if needed.