### PR TITLE
fix missing output data from test run process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-editor-support",
-  "version": "30.1.0",
+  "version": "30.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/jest-community/jest-editor-support"
@@ -9,7 +9,6 @@
   "main": "build/index.js",
   "lint-staged": {
     "*.json": [
-      "yarn prettier-write",
       "git add"
     ],
     "*.js": "eslint --cache --fix"

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -148,6 +148,9 @@ export default class Runner extends EventEmitter {
     const msgType = this.findMessageType(data);
     switch (msgType) {
       case messageTypes.testResults:
+        this.emit('executableStdErr', data, {
+          type: msgType,
+        });
         readFile(this.outputPath, 'utf8', (err, _data) => {
           if (err) {
             const message = `JSON report not found at ${this.outputPath}`;
@@ -175,6 +178,7 @@ export default class Runner extends EventEmitter {
             type: msgType,
           });
         } else {
+          // remove clear screen escape sequence
           this.emit('executableOutput', data.toString().replace('[2J[H', ''));
         }
         this.prevMessageTypes.length = 0;


### PR DESCRIPTION
when output matches messageTypes.testResults, the whole buffer is discarded, which caused missing output. This PR ensures all output of the process is reported.
