### PR TITLE
fix dashed-args for custom args

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ export {JESParserPluginOptions, JESParserOptions, createProjectWorkspace, Projec
 export interface RunArgs {
   args: string[];
   replace?: boolean; // default is false
+  skipConversion?: boolean, // if true, args will not go through any conversion, such as dashed arg conversion.
 }
 export type SnapshotData = Record<string, string>;
 export interface Options {

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -53,9 +53,21 @@ export default class Runner extends EventEmitter {
     this._exited = false;
   }
 
+  __convertDashedArgs(args: string[]): string[] {
+    if (!this.workspace.useDashedArgs) {
+      return args;
+    }
+
+    return args.map((arg) =>
+      arg && arg.startsWith('--') && arg.length > 2 ? arg.replace(/(\B)([A-Z])/gm, '-$2').toLowerCase() : arg
+    );
+  }
+
   _getArgs(): string[] {
     if (this.options.args && this.options.args.replace) {
-      return this.options.args.args;
+      return this.options.args.skipConversion
+        ? this.options.args.args
+        : this.__convertDashedArgs(this.options.args.args);
     }
 
     // Handle the arg change on v18
@@ -88,11 +100,7 @@ export default class Runner extends EventEmitter {
     if (this.options.args) {
       args.push(...this.options.args.args);
     }
-    if (this.workspace.useDashedArgs) {
-      args = args.map((arg) =>
-        arg && arg.startsWith('--') && arg.length > 2 ? arg.replace(/(\B)([A-Z])/gm, '-$2').toLowerCase() : arg
-      );
-    }
+    args = this.__convertDashedArgs(args);
 
     return args;
   }

--- a/src/__tests__/runner.test.js
+++ b/src/__tests__/runner.test.js
@@ -327,11 +327,14 @@ describe('Runner', () => {
       expect(args[0]).toBe(expected);
     });
 
-    it('converts user passed in args', () => {
-      const expected = '--foo-bar-baz';
-
+    it.each`
+      argOption                                                       | expected
+      ${{args: ['--fooBarBaz']}}                                      | ${'--foo-bar-baz'}
+      ${{args: ['--fooBarBaz'], replace: true}}                       | ${'--foo-bar-baz'}
+      ${{args: ['--fooBarBaz'], replace: true, skipConversion: true}} | ${'--fooBarBaz'}
+    `('converts user passed in args', ({argOption, expected}) => {
       const workspace: any = {useDashedArgs: true};
-      const options = {args: {args: ['--fooBarBaz']}};
+      const options = {args: argOption};
       const sut = new Runner(workspace, options);
       sut.start(false);
 

--- a/src/types.js
+++ b/src/types.js
@@ -18,6 +18,7 @@ export type Location = {
 export type RunArgs = {
   args: Array<string>,
   replace?: boolean, // default is false
+  skipConversion?: boolean, // if true, args will not go through any conversion, such as dashed arg conversion.
 };
 
 export type Options = {


### PR DESCRIPTION
Address issues raised in jest-community/vscode-jest#1034 that the custom args with "replace" flag didn't get proper treatment for dashedArgs.